### PR TITLE
Create GET /v2/issuer/{type} that accepts a cohort

### DIFF
--- a/server/issuers.go
+++ b/server/issuers.go
@@ -75,7 +75,7 @@ func (c *Server) issuerHandlerV1(w http.ResponseWriter, r *http.Request) *handle
 	defer closers.Panic(r.Body)
 
 	if issuerType := chi.URLParam(r, "type"); issuerType != "" {
-		issuer, appErr := c.getLatestIssuer(issuerType, 1)
+		issuer, appErr := c.getLatestIssuer(issuerType, 0)
 		if appErr != nil {
 			return appErr
 		}

--- a/server/issuers.go
+++ b/server/issuers.go
@@ -75,7 +75,7 @@ func (c *Server) issuerHandlerV1(w http.ResponseWriter, r *http.Request) *handle
 	defer closers.Panic(r.Body)
 
 	if issuerType := chi.URLParam(r, "type"); issuerType != "" {
-		issuer, appErr := c.getLatestIssuer(issuerType)
+		issuer, appErr := c.getLatestIssuer(issuerType, 1)
 		if appErr != nil {
 			return appErr
 		}

--- a/server/server.go
+++ b/server/server.go
@@ -148,8 +148,10 @@ func (c *Server) setupRouter(ctx context.Context, logger *logrus.Logger) (contex
 	c.Logger = logger
 
 	r.Mount("/v1/blindedToken", c.tokenRouterV1())
-	r.Mount("/v1/issuer", c.issuerRouter())
+	r.Mount("/v1/issuer", c.issuerRouterV1())
+
 	r.Mount("/v2/blindedToken", c.tokenRouterV2())
+	r.Mount("/v2/issuer", c.issuerRouterV2())
 	r.Get("/metrics", middleware.Metrics())
 
 	return ctx, r

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -94,7 +94,7 @@ func (suite *ServerTestSuite) createIssuer(serverURL string, issuerType string, 
 	suite.Assert().Equal(http.StatusOK, resp.StatusCode)
 
 	payload = fmt.Sprintf(`{"cohort": %d}`, issuerCohort)
-	issuerURL := fmt.Sprintf("%s/v1/issuer/%s", serverURL, issuerType)
+	issuerURL := fmt.Sprintf("%s/v2/issuer/%s", serverURL, issuerType)
 	resp, err = suite.request("GET", issuerURL, bytes.NewBuffer([]byte(payload)))
 	suite.Require().NoError(err, "Issuer fetch must succeed")
 	suite.Assert().Equal(http.StatusOK, resp.StatusCode)
@@ -141,7 +141,7 @@ func (suite *ServerTestSuite) createIssuerWithExpiration(serverURL string, issue
 	suite.Assert().Equal(http.StatusOK, resp.StatusCode)
 
 	payload = fmt.Sprintf(`{"cohort": %d}`, issuerCohort)
-	issuerURL := fmt.Sprintf("%s/v1/issuer/%s", serverURL, issuerType)
+	issuerURL := fmt.Sprintf("%s/v2/issuer/%s", serverURL, issuerType)
 	resp, err = suite.request("GET", issuerURL, bytes.NewBuffer([]byte(payload)))
 	suite.Require().NoError(err, "Issuer fetch must succeed")
 	suite.Assert().Equal(http.StatusOK, resp.StatusCode)


### PR DESCRIPTION
We made a breaking change to the V1 endpoint (accepting a cohort in the
request body), which broke the client (ads).  This commit reverts the v1
endpoint to how it was before and creates a new /v2/ endpoint to fetch
by cohort.