### PR TITLE
define a constant to encode the cohort of v1

### DIFF
--- a/server/issuers.go
+++ b/server/issuers.go
@@ -33,10 +33,10 @@ type issuerFetchRequestV2 struct {
 }
 
 func (c *Server) getLatestIssuer(issuerType string, issuerCohort int) (*Issuer, *handlers.AppError) {
-	issuer, err := c.fetchIssuersByCohort(issuerType, issuerCohort)
+	issuer, err := c.fetchIssuegirsByCohort(issuerType, issuerCohort)
 	if err != nil {
 		if err == errIssuerCohortNotFound {
-			c.Logger.Error("Issuer with give cohort not found")
+			c.Logger.Error("Issuer with given cohort not found")
 			return nil, &handlers.AppError{
 				Message: "Issuer with given cohort not found",
 				Code:    404,

--- a/server/issuers.go
+++ b/server/issuers.go
@@ -75,7 +75,7 @@ func (c *Server) issuerHandlerV1(w http.ResponseWriter, r *http.Request) *handle
 	defer closers.Panic(r.Body)
 
 	if issuerType := chi.URLParam(r, "type"); issuerType != "" {
-		issuer, appErr := c.getLatestIssuer(issuerType, 0)
+		issuer, appErr := c.getLatestIssuer(issuerType, v1Cohort)
 		if appErr != nil {
 			return appErr
 		}

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -226,7 +226,7 @@ func (suite *ServerTestSuite) attemptRedeem(serverURL string, preimageText []byt
 
 func (suite *ServerTestSuite) TestIssueRedeem() {
 	issuerType := "test"
-	issuerCohort := 1
+	issuerCohort := v1Cohort
 	msg := "test message"
 
 	server := httptest.NewServer(suite.handler)
@@ -247,7 +247,7 @@ func (suite *ServerTestSuite) TestIssueRedeem() {
 
 func (suite *ServerTestSuite) TestIssuerGetAll() {
 	issuerType := "test2"
-	issuerCohort := 1
+	issuerCohort := v1Cohort
 
 	server := httptest.NewServer(suite.handler)
 	defer server.Close()
@@ -261,7 +261,7 @@ func (suite *ServerTestSuite) TestIssuerGetAll() {
 
 func (suite *ServerTestSuite) TestIssueRedeemV2() {
 	issuerType := "test2"
-	issuerCohort := 1
+	issuerCohort := v1Cohort
 	msg := "test message 2"
 
 	server := httptest.NewServer(suite.handler)
@@ -367,7 +367,7 @@ func (suite *ServerTestSuite) createCohortTokens(serverURL string, issuerType st
 
 func (suite *ServerTestSuite) TestNewIssueRedeemV2() {
 	issuerType := "test2"
-	issuerCohort := 0
+	issuerCohort := 1 - v1Cohort
 	msg := "test message 2"
 
 	server := httptest.NewServer(suite.handler)

--- a/server/tokens.go
+++ b/server/tokens.go
@@ -14,6 +14,10 @@ import (
 	"github.com/go-chi/chi"
 )
 
+const (
+	v1Cohort = 1
+)
+
 type blindedTokenIssueRequest struct {
 	BlindedTokens []*crypto.BlindedToken `json:"blinded_tokens"`
 }
@@ -98,10 +102,10 @@ func (c *Server) BlindedTokenIssuerHandlerV2(w http.ResponseWriter, r *http.Requ
 	return nil
 }
 
-// Old endpoint, that always handles tokens with cohort = 1
+// Old endpoint, that always handles tokens with v1cohort
 func (c *Server) blindedTokenIssuerHandler(w http.ResponseWriter, r *http.Request) *handlers.AppError {
 	if issuerType := chi.URLParam(r, "type"); issuerType != "" {
-		issuer, appErr := c.getLatestIssuer(issuerType, 1)
+		issuer, appErr := c.getLatestIssuer(issuerType, v1Cohort)
 		if appErr != nil {
 			return appErr
 		}
@@ -223,8 +227,8 @@ func (c *Server) blindedTokenBulkRedeemHandler(w http.ResponseWriter, r *http.Re
 
 	for _, token := range request.Tokens {
 		// todo: this code seems to be from an old version - we use the `redeemTokenWithDB`, and we have no tests, so I
-		// assume that is no longer used, hence the usage of Cohort 1.
-		issuer, appErr := c.getLatestIssuer(token.Issuer, 1)
+		// assume that is no longer used, hence the usage of v1Cohort.
+		issuer, appErr := c.getLatestIssuer(token.Issuer, v1Cohort)
 
 		if appErr != nil {
 			_ = tx.Rollback()


### PR DESCRIPTION
* included a cohort in package `server` to maintain consistency when referring to the cohort of v1