### PR TITLE
Move Redemption Connnection Cancel Deferral

### DIFF
--- a/server/db.go
+++ b/server/db.go
@@ -391,6 +391,7 @@ func (c *Server) createIssuer(issuerType string, maxTokens int, expiresAt *time.
 		maxTokens,
 		expiresAt,
 	)
+	defer rows.Close()
 	if err != nil {
 		return err
 	}
@@ -402,7 +403,6 @@ func (c *Server) createIssuer(issuerType string, maxTokens int, expiresAt *time.
 		}
 	}
 
-	defer rows.Close()
 	return nil
 }
 

--- a/server/db.go
+++ b/server/db.go
@@ -429,13 +429,13 @@ func redeemTokenWithDB(db Queryable, issuer string, preimage *crypto.TokenPreima
 	queryTimer := prometheus.NewTimer(createRedemptionDBDuration)
 	rows, err := db.Query(
 		`INSERT INTO redemptions(id, issuer_type, ts, payload) VALUES ($1, $2, NOW(), $3)`, preimageTxt, issuer, payload)
+	defer rows.Close()
 	if err != nil {
 		if err, ok := err.(*pq.Error); ok && err.Code == "23505" { // unique constraint violation
 			return errDuplicateRedemption
 		}
 		return err
 	}
-	defer rows.Close()
 
 	queryTimer.ObserveDuration()
 	return nil

--- a/server/db.go
+++ b/server/db.go
@@ -452,14 +452,13 @@ func (c *Server) fetchRedemption(issuerType, ID string) (*Redemption, error) {
 	queryTimer := prometheus.NewTimer(fetchRedemptionDBDuration)
 	rows, err := c.db.Query(
 		`SELECT id, issuer_id, ts, payload FROM redemptions WHERE id = $1 AND issuer_type = $2`, ID, issuerType)
+	defer rows.Close()
 
 	queryTimer.ObserveDuration()
 
 	if err != nil {
 		return nil, err
 	}
-
-	defer rows.Close()
 
 	if rows.Next() {
 		var redemption = &Redemption{}


### PR DESCRIPTION
Shift up deferral to close row selection after redemption write in order to ensure
that the Query connection is returned to the pool on error.