### PR TITLE
Batching

### DIFF
--- a/kafka/signed_blinded_token_issuer_handler.go
+++ b/kafka/signed_blinded_token_issuer_handler.go
@@ -23,8 +23,9 @@ func SignedBlindedTokenIssuerHandler(
 	data []byte,
 	producer *kafka.Writer,
 	server *cbpServer.Server,
+	results chan *ProcessingError,
 	logger *zerolog.Logger,
-) error {
+) *ProcessingError {
 	const (
 		OK             = 0
 		INVALID_ISSUER = 1
@@ -32,13 +33,29 @@ func SignedBlindedTokenIssuerHandler(
 	)
 	blindedTokenRequestSet, err := avroSchema.DeserializeSigningRequestSet(bytes.NewReader(data))
 	if err != nil {
-		return errors.New(fmt.Sprintf("Request %s: Failed Avro deserialization: %e", blindedTokenRequestSet.Request_id, err))
+		message := fmt.Sprintf(
+			"Request %s: Failed Avro deserialization",
+			blindedTokenRequestSet.Request_id,
+		)
+		return &ProcessingError{
+			Cause:     err,
+			Message:   message,
+			Temporary: false,
+		}
 	}
 	var blindedTokenResults []avroSchema.SigningResult
 	if len(blindedTokenRequestSet.Data) > 1 {
 		// NOTE: When we start supporting multiple requests we will need to review
 		// errors and return values as well.
-		return errors.New(fmt.Sprintf("Request %s: Data array unexpectedly contained more than a single message. This array is intended to make future extension easier, but no more than a single value is currently expected.", blindedTokenRequestSet.Request_id))
+		message := fmt.Sprintf(
+			"Request %s: Data array unexpectedly contained more than a single message. This array is intended to make future extension easier, but no more than a single value is currently expected.",
+			blindedTokenRequestSet.Request_id,
+		)
+		return &ProcessingError{
+			Cause:     errors.New(message),
+			Message:   message,
+			Temporary: false,
+		}
 	}
 	for _, request := range blindedTokenRequestSet.Data {
 		if request.Blinded_tokens == nil {
@@ -75,7 +92,10 @@ func SignedBlindedTokenIssuerHandler(
 			blindedToken := crypto.BlindedToken{}
 			err := blindedToken.UnmarshalText([]byte(stringBlindedToken))
 			if err != nil {
-				logger.Error().Msg(fmt.Sprintf("Request %s: failed to unmarshal blinded tokens: %e", blindedTokenRequestSet.Request_id, err))
+				logger.Error().Msg(fmt.Sprintf(
+					"Request %s: failed to unmarshal blinded tokens: %e",
+					blindedTokenRequestSet.Request_id, err,
+				))
 				blindedTokenResults = append(blindedTokenResults, avroSchema.SigningResult{
 					Signed_tokens:     nil,
 					Issuer_public_key: "",
@@ -89,7 +109,11 @@ func SignedBlindedTokenIssuerHandler(
 		// @TODO: If one token fails they will all fail. Assess this behavior
 		signedTokens, dleqProof, err := btd.ApproveTokens(blindedTokens, issuer.SigningKey)
 		if err != nil {
-			logger.Error().Msg(fmt.Sprintf("Request %s: Could not approve new tokens: %e", blindedTokenRequestSet.Request_id, err))
+			logger.Error().Msg(fmt.Sprintf(
+				"Request %s: Could not approve new tokens: %e",
+				blindedTokenRequestSet.Request_id,
+				err,
+			))
 			blindedTokenResults = append(blindedTokenResults, avroSchema.SigningResult{
 				Signed_tokens:     nil,
 				Issuer_public_key: "",
@@ -100,38 +124,44 @@ func SignedBlindedTokenIssuerHandler(
 		}
 		marshaledDLEQProof, err := dleqProof.MarshalText()
 		if err != nil {
-			return errors.New(
-				fmt.Sprintf(
-					"Request %s: Could not marshal DLEQ proof: %e",
-					blindedTokenRequestSet.Request_id,
-					err,
-				),
+			message := fmt.Sprintf(
+				"Request %s: Could not marshal DLEQ proof",
+				blindedTokenRequestSet.Request_id,
 			)
+			return &ProcessingError{
+				Cause:     err,
+				Message:   message,
+				Temporary: false,
+			}
 		}
 		var marshaledTokens []string
 		for _, token := range signedTokens {
 			marshaledToken, err := token.MarshalText()
 			if err != nil {
-				return errors.New(
-					fmt.Sprintf(
-						"Request %s: Could not marshal new tokens to bytes: %e",
-						blindedTokenRequestSet.Request_id,
-						err,
-					),
+				message := fmt.Sprintf(
+					"Request %s: Could not marshal new tokens to bytes: %e",
+					blindedTokenRequestSet.Request_id,
 				)
+				return &ProcessingError{
+					Cause:     err,
+					Message:   message,
+					Temporary: false,
+				}
 			}
 			marshaledTokens = append(marshaledTokens, string(marshaledToken[:]))
 		}
 		publicKey := issuer.SigningKey.PublicKey()
 		marshaledPublicKey, err := publicKey.MarshalText()
 		if err != nil {
-			return errors.New(
-				fmt.Sprintf(
-					"Request %s: Could not marshal signing key: %e",
-					blindedTokenRequestSet.Request_id,
-					err,
-				),
+			message := fmt.Sprintf(
+				"Request %s: Could not marshal signing key: %e",
+				blindedTokenRequestSet.Request_id,
 			)
+			return &ProcessingError{
+				Cause:     err,
+				Message:   message,
+				Temporary: false,
+			}
 		}
 		blindedTokenResults = append(blindedTokenResults, avroSchema.SigningResult{
 			Signed_tokens:     marshaledTokens,
@@ -148,11 +178,29 @@ func SignedBlindedTokenIssuerHandler(
 	var resultSetBuffer bytes.Buffer
 	err = resultSet.Serialize(&resultSetBuffer)
 	if err != nil {
-		return errors.New(fmt.Sprintf("Request %s: Failed to serialize ResultSet: %s", blindedTokenRequestSet.Request_id, resultSet))
+		message := fmt.Sprintf(
+			"Request %s: Failed to serialize ResultSet: %s",
+			blindedTokenRequestSet.Request_id,
+			resultSet,
+		)
+		return &ProcessingError{
+			Cause:     err,
+			Message:   message,
+			Temporary: false,
+		}
 	}
 	err = Emit(producer, resultSetBuffer.Bytes(), logger)
 	if err != nil {
-		return errors.New(fmt.Sprintf("Request %s: Failed to emit results to topic %s: %e", blindedTokenRequestSet.Request_id, producer.Topic, err))
+		message := fmt.Sprintf(
+			"Request %s: Failed to emit results to topic %s",
+			blindedTokenRequestSet.Request_id,
+			producer.Topic,
+		)
+		return &ProcessingError{
+			Cause:     err,
+			Message:   message,
+			Temporary: false,
+		}
 	}
 	return nil
 }

--- a/kafka/signed_blinded_token_issuer_handler.go
+++ b/kafka/signed_blinded_token_issuer_handler.go
@@ -22,6 +22,7 @@ import (
 func SignedBlindedTokenIssuerHandler(
 	msg kafka.Message,
 	producer *kafka.Writer,
+	tolerableEquivalence []cbpServer.Equivalence,
 	server *cbpServer.Server,
 	results chan *ProcessingError,
 	logger *zerolog.Logger,

--- a/kafka/signed_blinded_token_issuer_handler.go
+++ b/kafka/signed_blinded_token_issuer_handler.go
@@ -20,7 +20,7 @@ import (
  as an argument here. That will require a bit of refactoring.
 */
 func SignedBlindedTokenIssuerHandler(
-	data []byte,
+	msg kafka.Message,
 	producer *kafka.Writer,
 	server *cbpServer.Server,
 	results chan *ProcessingError,
@@ -31,6 +31,7 @@ func SignedBlindedTokenIssuerHandler(
 		INVALID_ISSUER = 1
 		ERROR          = 2
 	)
+	data := msg.Value
 	blindedTokenRequestSet, err := avroSchema.DeserializeSigningRequestSet(bytes.NewReader(data))
 	if err != nil {
 		message := fmt.Sprintf(
@@ -38,9 +39,10 @@ func SignedBlindedTokenIssuerHandler(
 			blindedTokenRequestSet.Request_id,
 		)
 		return &ProcessingError{
-			Cause:     err,
-			Message:   message,
-			Temporary: false,
+			Cause:          err,
+			FailureMessage: message,
+			Temporary:      false,
+			KafkaMessage:   msg,
 		}
 	}
 	var blindedTokenResults []avroSchema.SigningResult
@@ -52,9 +54,10 @@ func SignedBlindedTokenIssuerHandler(
 			blindedTokenRequestSet.Request_id,
 		)
 		return &ProcessingError{
-			Cause:     errors.New(message),
-			Message:   message,
-			Temporary: false,
+			Cause:          errors.New(message),
+			FailureMessage: message,
+			Temporary:      false,
+			KafkaMessage:   msg,
 		}
 	}
 	for _, request := range blindedTokenRequestSet.Data {
@@ -129,9 +132,10 @@ func SignedBlindedTokenIssuerHandler(
 				blindedTokenRequestSet.Request_id,
 			)
 			return &ProcessingError{
-				Cause:     err,
-				Message:   message,
-				Temporary: false,
+				Cause:          err,
+				FailureMessage: message,
+				Temporary:      false,
+				KafkaMessage:   msg,
 			}
 		}
 		var marshaledTokens []string
@@ -143,9 +147,10 @@ func SignedBlindedTokenIssuerHandler(
 					blindedTokenRequestSet.Request_id,
 				)
 				return &ProcessingError{
-					Cause:     err,
-					Message:   message,
-					Temporary: false,
+					Cause:          err,
+					FailureMessage: message,
+					Temporary:      false,
+					KafkaMessage:   msg,
 				}
 			}
 			marshaledTokens = append(marshaledTokens, string(marshaledToken[:]))
@@ -158,9 +163,10 @@ func SignedBlindedTokenIssuerHandler(
 				blindedTokenRequestSet.Request_id,
 			)
 			return &ProcessingError{
-				Cause:     err,
-				Message:   message,
-				Temporary: false,
+				Cause:          err,
+				FailureMessage: message,
+				Temporary:      false,
+				KafkaMessage:   msg,
 			}
 		}
 		blindedTokenResults = append(blindedTokenResults, avroSchema.SigningResult{
@@ -184,9 +190,10 @@ func SignedBlindedTokenIssuerHandler(
 			resultSet,
 		)
 		return &ProcessingError{
-			Cause:     err,
-			Message:   message,
-			Temporary: false,
+			Cause:          err,
+			FailureMessage: message,
+			Temporary:      false,
+			KafkaMessage:   msg,
 		}
 	}
 	err = Emit(producer, resultSetBuffer.Bytes(), logger)
@@ -197,9 +204,10 @@ func SignedBlindedTokenIssuerHandler(
 			producer.Topic,
 		)
 		return &ProcessingError{
-			Cause:     err,
-			Message:   message,
-			Temporary: false,
+			Cause:          err,
+			FailureMessage: message,
+			Temporary:      false,
+			KafkaMessage:   msg,
 		}
 	}
 	return nil

--- a/main.go
+++ b/main.go
@@ -23,7 +23,10 @@ func main() {
 	serverCtx, logger := server.SetupLogger(context.Background())
 	zeroLogger := zerolog.New(os.Stderr).With().Timestamp().Caller().Logger()
 	if os.Getenv("ENV") != "production" {
-		zerolog.SetGlobalLevel(zerolog.TraceLevel)
+		zerolog.SetGlobalLevel(zerolog.WarnLevel)
+		if os.Getenv("ENV") == "local" {
+			zerolog.SetGlobalLevel(zerolog.TraceLevel)
+		}
 	}
 
 	srv := *server.DefaultServer

--- a/server/db.go
+++ b/server/db.go
@@ -75,6 +75,7 @@ type RedemptionV2 struct {
 	Timestamp time.Time `json:"timestamp"`
 	Payload   string    `json:"payload"`
 	TTL       int64     `json:"TTL"`
+	Offset    int64     `json:"offset"`
 }
 
 // CacheInterface cach functions
@@ -468,12 +469,12 @@ type Queryable interface {
 	Query(query string, args ...interface{}) (*sql.Rows, error)
 }
 
-func (c *Server) RedeemToken(issuerForRedemption *Issuer, preimage *crypto.TokenPreimage, payload string) error {
+func (c *Server) RedeemToken(issuerForRedemption *Issuer, preimage *crypto.TokenPreimage, payload string, offset int64) error {
 	defer incrementCounter(redeemTokenCounter)
 	if issuerForRedemption.Version == 1 {
 		return redeemTokenWithDB(c.db, issuerForRedemption.IssuerType, preimage, payload)
 	} else if issuerForRedemption.Version == 2 {
-		return c.redeemTokenV2(issuerForRedemption, preimage, payload)
+		return c.redeemTokenV2(issuerForRedemption, preimage, payload, offset)
 	}
 	return errors.New("Wrong Issuer Version")
 }

--- a/server/dynamo.go
+++ b/server/dynamo.go
@@ -85,7 +85,7 @@ func (c *Server) fetchRedemptionV2(issuer *Issuer, ID string) (*RedemptionV2, er
 	return &redemption, nil
 }
 
-func (c *Server) redeemTokenV2(issuer *Issuer, preimage *crypto.TokenPreimage, payload string) error {
+func (c *Server) redeemTokenV2(issuer *Issuer, preimage *crypto.TokenPreimage, payload string, offset int64) error {
 	preimageTxt, err := preimage.MarshalText()
 	if err != nil {
 		c.Logger.Error("Error Marshalling preimage")
@@ -107,6 +107,7 @@ func (c *Server) redeemTokenV2(issuer *Issuer, preimage *crypto.TokenPreimage, p
 		Payload:   payload,
 		Timestamp: time.Now(),
 		TTL:       issuer.ExpiresAt.Unix(),
+		Offset:    offset,
 	}
 
 	av, err := dynamodbattribute.MarshalMap(redemption)
@@ -161,7 +162,7 @@ func (c *Server) PersistRedemption(redemption RedemptionV2) error {
 // checkRedeemedTokenEquivalence returns whether just the ID of a given RedemptionV2 token
 // matches an existing persisted record, the whole value matches, or neither match and
 // this is a new token to be redeemed.
-func (c *Server) CheckRedeemedTokenEquivalence(issuer *Issuer, preimage *crypto.TokenPreimage, payload string) (*RedemptionV2, Equivalence, error) {
+func (c *Server) CheckRedeemedTokenEquivalence(issuer *Issuer, preimage *crypto.TokenPreimage, payload string, offset int64) (*RedemptionV2, Equivalence, error) {
 	preimageTxt, err := preimage.MarshalText()
 	if err != nil {
 		c.Logger.Error("Error Marshalling preimage")
@@ -182,6 +183,7 @@ func (c *Server) CheckRedeemedTokenEquivalence(issuer *Issuer, preimage *crypto.
 		Payload:   payload,
 		Timestamp: time.Now(),
 		TTL:       issuer.ExpiresAt.Unix(),
+		Offset:    offset,
 	}
 
 	existingRedemption, err := c.fetchRedemptionV2(issuer, id.String())

--- a/server/dynamo.go
+++ b/server/dynamo.go
@@ -14,6 +14,15 @@ import (
 	uuid "github.com/satori/go.uuid"
 )
 
+type Equivalence int64
+
+const (
+	UnknownEquivalence Equivalence = iota
+	NoEquivalence
+	IdEquivalence
+	IdAndAllValueEquivalence
+)
+
 func (c *Server) InitDynamo() {
 	sess := session.Must(session.NewSessionWithOptions(session.Options{
 		SharedConfigState: session.SharedConfigEnable,
@@ -122,4 +131,70 @@ func (c *Server) redeemTokenV2(issuer *Issuer, preimage *crypto.TokenPreimage, p
 		return err
 	}
 	return nil
+}
+
+func (c *Server) PersistRedemption(redemption RedemptionV2) error {
+	av, err := dynamodbattribute.MarshalMap(redemption)
+	if err != nil {
+		c.Logger.Error("Error marshalling redemption")
+		return err
+	}
+
+	input := &dynamodb.PutItemInput{
+		Item:                av,
+		ConditionExpression: aws.String("attribute_not_exists(id)"),
+		TableName:           aws.String("redemptions"),
+	}
+
+	_, err = c.dynamo.PutItem(input)
+	if err != nil {
+		if err, ok := err.(awserr.Error); ok && err.Code() == "ConditionalCheckFailedException" { // unique constraint violation
+			c.Logger.Error("Duplicate redemption")
+			return errDuplicateRedemption
+		}
+		c.Logger.Error("Error creating item")
+		return err
+	}
+	return nil
+}
+
+// checkRedeemedTokenEquivalence returns whether just the ID of a given RedemptionV2 token
+// matches an existing persisted record, the whole value matches, or neither match and
+// this is a new token to be redeemed.
+func (c *Server) CheckRedeemedTokenEquivalence(issuer *Issuer, preimage *crypto.TokenPreimage, payload string) (*RedemptionV2, Equivalence, error) {
+	preimageTxt, err := preimage.MarshalText()
+	if err != nil {
+		c.Logger.Error("Error Marshalling preimage")
+		return nil, UnknownEquivalence, err
+	}
+
+	issuerUUID, err := uuid.FromString(issuer.ID)
+	if err != nil {
+		c.Logger.Error("Bad issuer id")
+		return nil, UnknownEquivalence, errors.New("Bad issuer id")
+	}
+	id := uuid.NewV5(issuerUUID, string(preimageTxt))
+
+	redemption := RedemptionV2{
+		IssuerID:  issuer.ID,
+		ID:        id.String(),
+		PreImage:  string(preimageTxt),
+		Payload:   payload,
+		Timestamp: time.Now(),
+		TTL:       issuer.ExpiresAt.Unix(),
+	}
+
+	existingRedemption, err := c.fetchRedemptionV2(issuer, id.String())
+
+	// If err is nil that means that the record does exist in the database and we need
+	// to determine whether the body is equivalent to what was provided or just the
+	// id.
+	if err == nil {
+		if redemption == *existingRedemption {
+			return &redemption, IdAndAllValueEquivalence, nil
+		} else {
+			return &redemption, IdEquivalence, nil
+		}
+	}
+	return &redemption, NoEquivalence, nil
 }

--- a/server/tokens.go
+++ b/server/tokens.go
@@ -191,7 +191,10 @@ func (c *Server) blindedTokenRedeemHandler(w http.ResponseWriter, r *http.Reques
 			}
 		}
 
-		if err := c.RedeemToken(verifiedIssuer, request.TokenPreimage, request.Payload); err != nil {
+		// HTTP requests will not have an offset, which was added to RedeemToken
+		// to manage the new Kafka flow and its associated uniqueness constraints.
+		// Setting to 0 until the HTTP flow is deprecated.
+		if err := c.RedeemToken(verifiedIssuer, request.TokenPreimage, request.Payload, 0); err != nil {
 			if err == errDuplicateRedemption {
 				return &handlers.AppError{
 					Message: err.Error(),


### PR DESCRIPTION
Rather than pulling all messages out of Kafka and processing them in parallel and ignoring errors, use proper batching that retries temporary errors and alerts and progresses on permanent errors.

`kafka-go` exposes messages one at a time through its normal interfaces despite collecting messages with batching from Kafka. To process these messages in parallel we use the `FetchMessage` method in a loop to collect a set of messages for processing. Successes and permanent failures are committed and temporary failures are not committed and are retried. Miscategorization of errors can cause the consumer to become stuck forever, so it's important that permanent failures are not categorized as temporary.