### PR TITLE
adding debugging to tell what the temp error is

### DIFF
--- a/kafka/main.go
+++ b/kafka/main.go
@@ -4,6 +4,7 @@ package kafka
 import (
 	"context"
 	"errors"
+	"fmt"
 	"io"
 	"os"
 	"strings"
@@ -120,8 +121,8 @@ func readAndCommitBatchPipelineResults(
 	}
 	err := <-msgCtx.errorResult
 	if err != nil {
-		logger.Error().Msg("temporary failure encountered")
-		return errors.New("temporary failure encountered")
+		logger.Error().Err(err).Msg("temporary failure encountered")
+		return fmt.Errorf("temporary failure encountered: %w", err)
 	}
 	logger.Info().Msgf("Committing offset %d", msgCtx.msg.Offset)
 	if err := reader.CommitMessages(ctx, msgCtx.msg); err != nil {

--- a/kafka/signed_blinded_token_issuer_handler.go
+++ b/kafka/signed_blinded_token_issuer_handler.go
@@ -194,6 +194,12 @@ OUTER:
 			for i := 0; i < len(blindedTokens); i += numT {
 				count++
 				if count > len(issuer.Keys) {
+					// perform a rotation in an attempt to get that last key
+					if err := server.RotateIssuersV3(); err != nil {
+						// temporary error returned, rotation failed, try again next time
+						return errors.New("failed to rotate issuer: not enough keys for signing request")
+					}
+					// temporary error returned, have the message retried as we just performed a rotation
 					return fmt.Errorf("num keys %d: error invalid number of blindedTokens, not enough keys for signing request",
 						len(issuer.Keys))
 				}

--- a/server/db.go
+++ b/server/db.go
@@ -690,7 +690,9 @@ func (c *Server) rotateIssuersV3() error {
 			i.version = 3 and
 			i.expires_at is not null and
 			i.expires_at > now()
-			and (select max(end_at) from v3_issuer_keys where issuer_id=i.issuer_id) < now() + i.buffer * i.duration::interval
+			and (select max(end_at) from v3_issuer_keys where issuer_id=i.issuer_id) < now()
+				+ i.buffer * i.duration::interval
+				+ i.overlap * i.duration::interval
 		for update skip locked
 		`,
 	)

--- a/server/db.go
+++ b/server/db.go
@@ -658,7 +658,12 @@ func (c *Server) rotateIssuers() error {
 	return nil
 }
 
-// rotateIssuers is the function that rotates
+// RotateIssuersV3 is the function that rotates time aware issuers
+func (c *Server) RotateIssuersV3() error {
+	return c.rotateIssuersV3()
+}
+
+// rotateIssuersV3 is the function implementation that rotates time aware issuers
 func (c *Server) rotateIssuersV3() error {
 	tx := c.db.MustBegin()
 

--- a/server/server.go
+++ b/server/server.go
@@ -149,6 +149,11 @@ func (c *Server) setupRouter(ctx context.Context, logger *logrus.Logger) (contex
 
 	c.Logger = logger
 
+	// kick rotate v3 issuers on start
+	if err := c.rotateIssuersV3(); err != nil {
+		panic(err)
+	}
+
 	r.Mount("/v1/blindedToken", c.tokenRouterV1())
 	r.Mount("/v1/issuer", c.issuerRouterV1())
 

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -48,10 +48,10 @@ func (suite *ServerTestSuite) SetupSuite() {
 	err = suite.srv.InitDBConfig()
 	suite.Require().NoError(err, "Failed to setup db conn")
 
-	suite.handler = chi.ServerBaseContext(suite.srv.setupRouter(SetupLogger(context.Background())))
-
 	suite.srv.InitDB()
 	suite.srv.InitDynamo()
+
+	suite.handler = chi.ServerBaseContext(suite.srv.setupRouter(SetupLogger(context.Background())))
 
 	err = test.SetupDynamodbTables(suite.srv.dynamo)
 	suite.Require().NoError(err)


### PR DESCRIPTION
correct number of overlap/buffer keys for time aware issuers

kick off rotate issuers v3 on start