### PR TITLE
Thread issuer key retrieval

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -24,6 +24,7 @@ require (
 	github.com/segmentio/kafka-go v0.4.38
 	github.com/sirupsen/logrus v1.9.0
 	github.com/stretchr/testify v1.8.1
+	golang.org/x/sync v0.0.0-20220722155255-886fb9371eb4
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -1405,6 +1405,7 @@ golang.org/x/sync v0.0.0-20200625203802-6e8e738ad208/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20201207232520-09787c993a3a/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20210220032951-036812b2e83c/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+golang.org/x/sync v0.0.0-20220722155255-886fb9371eb4 h1:uVc8UZUe6tr40fFVnUP5Oj+veunVezqYl9z7DYw9xzw=
 golang.org/x/sync v0.0.0-20220722155255-886fb9371eb4/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20180224232135-f6cff0780e54/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180823144017-11551d06cbcc/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=

--- a/kafka/signed_blinded_token_issuer_handler.go
+++ b/kafka/signed_blinded_token_issuer_handler.go
@@ -17,19 +17,17 @@ import (
 	"github.com/segmentio/kafka-go"
 )
 
-/*
-SignedBlindedTokenIssuerHandler emits signed, blinded tokens based on provided blinded tokens.
-
-	In cases where there are unrecoverable errors that prevent progress we will return nil.
-	These permanent failure cases are different from cases where we encounter temporary
-	errors inside the request data. For permanent failures inside the data processing loop we
-	simply add the error to the results. However, temporary errors inside the loop should break
-	the loop and return non-nil just like the errors outside the data processing loop. This is
-	because future attempts to process permanent failure cases will not succeed.
-	@TODO: It would be better for the Server implementation and the Kafka implementation of
-	this behavior to share utility functions rather than passing an instance of the server
-	as an argument here. That will require a bit of refactoring.
-*/
+/*SignedBlindedTokenIssuerHandler emits signed, blinded tokens based on provided blinded tokens.
+* In cases where there are unrecoverable errors that prevent progress we will return nil.
+* These permanent failure cases are different from cases where we encounter temporary
+* errors inside the request data. For permanent failures inside the data processing loop we
+* simply add the error to the results. However, temporary errors inside the loop should break
+* the loop and return non-nil just like the errors outside the data processing loop. This is
+* because future attempts to process permanent failure cases will not succeed.
+* @TODO: It would be better for the Server implementation and the Kafka implementation of
+*   this behavior to share utility functions rather than passing an instance of the server
+*   as an argument here. That will require a bit of refactoring.
+**/
 func SignedBlindedTokenIssuerHandler(
 	msg kafka.Message,
 	producer *kafka.Writer,

--- a/kafka/signed_blinded_token_issuer_handler.go
+++ b/kafka/signed_blinded_token_issuer_handler.go
@@ -2,6 +2,7 @@ package kafka
 
 import (
 	"bytes"
+	"context"
 	"errors"
 	"fmt"
 	"math"
@@ -18,15 +19,16 @@ import (
 
 /*
 SignedBlindedTokenIssuerHandler emits signed, blinded tokens based on provided blinded tokens.
- In cases where there are unrecoverable errors that prevent progress we will return nil.
- These permanent failure cases are different from cases where we encounter temporary
- errors inside the request data. For permanent failures inside the data processing loop we
- simply add the error to the results. However, temporary errors inside the loop should break
- the loop and return non-nil just like the errors outside the data processing loop. This is
- because future attempts to process permanent failure cases will not succeed.
- @TODO: It would be better for the Server implementation and the Kafka implementation of
- this behavior to share utility functions rather than passing an instance of the server
- as an argument here. That will require a bit of refactoring.
+
+	In cases where there are unrecoverable errors that prevent progress we will return nil.
+	These permanent failure cases are different from cases where we encounter temporary
+	errors inside the request data. For permanent failures inside the data processing loop we
+	simply add the error to the results. However, temporary errors inside the loop should break
+	the loop and return non-nil just like the errors outside the data processing loop. This is
+	because future attempts to process permanent failure cases will not succeed.
+	@TODO: It would be better for the Server implementation and the Kafka implementation of
+	this behavior to share utility functions rather than passing an instance of the server
+	as an argument here. That will require a bit of refactoring.
 */
 func SignedBlindedTokenIssuerHandler(
 	msg kafka.Message,
@@ -127,7 +129,7 @@ OUTER:
 		}
 
 		logger.Info().Msgf("getting latest issuer: %+v with cohort: %+v", request.Issuer_type, request.Issuer_cohort)
-		issuer, appErr := server.GetLatestIssuerKafka(request.Issuer_type, int16(request.Issuer_cohort))
+		issuer, appErr := server.GetLatestIssuerKafka(context.Background(), request.Issuer_type, int16(request.Issuer_cohort))
 		if appErr != nil {
 			logger.Error().Err(appErr).Msg("error retrieving issuer")
 			var processingError *utils.ProcessingError

--- a/kafka/signed_token_redeem_handler.go
+++ b/kafka/signed_token_redeem_handler.go
@@ -17,13 +17,10 @@ import (
 	kafka "github.com/segmentio/kafka-go"
 )
 
-/*
-SignedTokenRedeemHandler emits payment tokens that correspond to the signed confirmation
-
-	tokens provided. If it encounters a permanent error, it emits a permanent result for that
-	item. If the error is temporary, an error is returned to indicate that progress cannot be
-	made.
-*/
+/*SignedTokenRedeemHandler emits payment tokens that correspond to the signed confirmation
+* tokens provided. If it encounters a permanent error, it emits a permanent result for that
+* item. If the error is temporary, an error is returned to indicate that progress cannot be made.
+**/
 func SignedTokenRedeemHandler(
 	msg kafka.Message,
 	producer *kafka.Writer,

--- a/kafka/signed_token_redeem_handler.go
+++ b/kafka/signed_token_redeem_handler.go
@@ -2,6 +2,7 @@ package kafka
 
 import (
 	"bytes"
+	"context"
 	"errors"
 	"fmt"
 	"strings"
@@ -18,9 +19,10 @@ import (
 
 /*
 SignedTokenRedeemHandler emits payment tokens that correspond to the signed confirmation
- tokens provided. If it encounters a permanent error, it emits a permanent result for that
- item. If the error is temporary, an error is returned to indicate that progress cannot be
- made.
+
+	tokens provided. If it encounters a permanent error, it emits a permanent result for that
+	item. If the error is temporary, an error is returned to indicate that progress cannot be
+	made.
 */
 func SignedTokenRedeemHandler(
 	msg kafka.Message,
@@ -65,7 +67,7 @@ func SignedTokenRedeemHandler(
 		)
 		return nil
 	}
-	issuers, err := server.FetchAllIssuers()
+	issuers, err := server.FetchAllIssuers(context.Background())
 	if err != nil {
 		if processingError, ok := err.(*utils.ProcessingError); ok && processingError.Temporary {
 			return processingError
@@ -150,7 +152,7 @@ func SignedTokenRedeemHandler(
 			)
 			return nil
 		}
-		for _, issuer := range *issuers {
+		for _, issuer := range issuers {
 			if !issuer.ExpiresAt.IsZero() && issuer.ExpiresAt.Before(time.Now()) {
 				continue
 			}

--- a/server/issuers.go
+++ b/server/issuers.go
@@ -69,7 +69,7 @@ func (c *Server) GetLatestIssuer(issuerType string, issuerCohort int16) (*Issuer
 		}
 	}
 
-	return &(*issuer)[0], nil
+	return &issuer[0], nil
 }
 
 // GetLatestIssuerKafka - get the issuer and any processing error
@@ -79,11 +79,11 @@ func (c *Server) GetLatestIssuerKafka(issuerType string, issuerCohort int16) (*I
 		return nil, err
 	}
 
-	return &(*issuer)[0], nil
+	return &issuer[0], nil
 }
 
 // GetIssuers - get all issuers by issuer type
-func (c *Server) GetIssuers(issuerType string) (*[]Issuer, error) {
+func (c *Server) GetIssuers(issuerType string) ([]Issuer, error) {
 	issuers, err := c.getIssuers(issuerType)
 	if err != nil {
 		c.Logger.Error(err)
@@ -92,7 +92,7 @@ func (c *Server) GetIssuers(issuerType string) (*[]Issuer, error) {
 	return issuers, nil
 }
 
-func (c *Server) getIssuers(issuerType string) (*[]Issuer, *handlers.AppError) {
+func (c *Server) getIssuers(issuerType string) ([]Issuer, *handlers.AppError) {
 	issuer, err := c.fetchIssuers(issuerType)
 	if err != nil {
 		if errors.Is(err, errIssuerNotFound) {
@@ -224,8 +224,8 @@ func (c *Server) issuerGetAllHandler(w http.ResponseWriter, r *http.Request) *ha
 			Code:    500,
 		}
 	}
-	respIssuers := []issuerResponse{}
-	for _, issuer := range *issuers {
+	respIssuers := make([]issuerResponse, len(issuers))
+	for idx, issuer := range issuers {
 		expiresAt := ""
 		if !issuer.ExpiresAt.IsZero() {
 			expiresAt = issuer.ExpiresAt.Format(time.RFC3339)
@@ -236,7 +236,7 @@ func (c *Server) issuerGetAllHandler(w http.ResponseWriter, r *http.Request) *ha
 			publicKey = k.SigningKey.PublicKey()
 		}
 
-		respIssuers = append(respIssuers, issuerResponse{issuer.ID.String(), issuer.IssuerType, publicKey, expiresAt, issuer.IssuerCohort})
+		respIssuers[idx] = issuerResponse{issuer.ID.String(), issuer.IssuerType, publicKey, expiresAt, issuer.IssuerCohort}
 	}
 
 	err := json.NewEncoder(w).Encode(respIssuers)

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -126,7 +126,7 @@ func (suite *ServerTestSuite) TestIssueRedeemV2() {
 
 	expiresAt := time.Now().AddDate(0, 0, 1)
 	publicKey := suite.createIssuerWithExpiration(server.URL, issuerType, issuerCohort, expiresAt)
-	issuer, _ := suite.srv.GetLatestIssuer(issuerType, issuerCohort)
+	issuer, _ := suite.srv.GetLatestIssuer(context.Background(), issuerType, issuerCohort)
 
 	unblindedToken := suite.createToken(server.URL, issuerType, publicKey)
 	preimageText, sigText := suite.prepareRedemption(unblindedToken, msg)
@@ -166,7 +166,7 @@ func (suite *ServerTestSuite) TestIssueRedeemV2() {
 	suite.Require().NoError(err, "failed to expire issuer")
 	defer r.Close()
 	// keys are what rotate now, not the issuer itself
-	issuer, _ = suite.srv.GetLatestIssuer(issuerType, issuerCohort)
+	issuer, _ = suite.srv.GetLatestIssuer(context.Background(), issuerType, issuerCohort)
 
 	resp, err = suite.attemptRedeem(server.URL, preimageText2, sigText2, issuerType, msg)
 	suite.Assert().NoError(err, "HTTP Request should complete")
@@ -197,7 +197,7 @@ func (suite *ServerTestSuite) TestNewIssueRedeemV2() {
 
 	expiresAt := time.Now().AddDate(0, 0, 1)
 	publicKey := suite.createIssuerWithExpiration(server.URL, issuerType, issuerCohort, expiresAt)
-	issuer, _ := suite.srv.GetLatestIssuer(issuerType, issuerCohort)
+	issuer, _ := suite.srv.GetLatestIssuer(context.Background(), issuerType, issuerCohort)
 
 	unblindedToken := suite.createCohortToken(server.URL, issuerType, issuerCohort, publicKey)
 	preimageText, sigText := suite.prepareRedemption(unblindedToken, msg)
@@ -268,7 +268,7 @@ func (suite *ServerTestSuite) TestRotateTimeAwareIssuer() {
 
 	// wait a few intervals after creation and check number of signing keys left
 	time.Sleep(2 * time.Second)
-	myIssuer, err := suite.srv.GetLatestIssuer(issuer.IssuerType, issuer.IssuerCohort)
+	myIssuer, err := suite.srv.GetLatestIssuer(context.Background(), issuer.IssuerType, issuer.IssuerCohort)
 	fmt.Println(err)
 	suite.Require().Equal(len(myIssuer.Keys), 1) // should be one left
 
@@ -276,7 +276,7 @@ func (suite *ServerTestSuite) TestRotateTimeAwareIssuer() {
 	err = suite.srv.rotateIssuersV3()
 	suite.Require().NoError(err)
 
-	myIssuer, _ = suite.srv.GetLatestIssuer(issuer.IssuerType, issuer.IssuerCohort)
+	myIssuer, _ = suite.srv.GetLatestIssuer(context.Background(), issuer.IssuerType, issuer.IssuerCohort)
 	suite.Require().Equal(len(myIssuer.Keys), 3) // should be 3 now
 
 	// rotate issuers should pick up that there are some new intervals to make up buffer and populate
@@ -286,7 +286,7 @@ func (suite *ServerTestSuite) TestRotateTimeAwareIssuer() {
 
 	// wait a few intervals after creation and check number of signing keys left
 	time.Sleep(2 * time.Second)
-	myIssuer, _ = suite.srv.GetLatestIssuer(issuer.IssuerType, issuer.IssuerCohort)
+	myIssuer, _ = suite.srv.GetLatestIssuer(context.Background(), issuer.IssuerType, issuer.IssuerCohort)
 	suite.Require().Equal(len(myIssuer.Keys), 1) // should be one left
 }
 
@@ -619,7 +619,7 @@ func (suite *ServerTestSuite) TestRedeemV3() {
 	err := suite.srv.createV3Issuer(issuer)
 	suite.Require().NoError(err)
 
-	issuerKey, _ := suite.srv.GetLatestIssuer(issuer.IssuerType, issuer.IssuerCohort)
+	issuerKey, _ := suite.srv.GetLatestIssuer(context.Background(), issuer.IssuerType, issuer.IssuerCohort)
 
 	tokens := make([]*crypto.Token, buffer)
 	blindedTokensSlice := make([]*crypto.BlindedToken, buffer)

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -63,7 +63,7 @@ func (suite *ServerTestSuite) SetupTest() {
 	tables := []string{"v3_issuer_keys", "v3_issuers", "redemptions"}
 
 	for _, table := range tables {
-		_, err := suite.srv.db.Exec("delete from " + table)
+		_, err := suite.srv.db.Exec(fmt.Sprintf("delete from %s", table))
 		suite.Require().NoError(err, "Failed to get clean table")
 	}
 }

--- a/server/tokens.go
+++ b/server/tokens.go
@@ -307,7 +307,7 @@ func (c *Server) blindedTokenRedeemHandler(w http.ResponseWriter, r *http.Reques
 		var verified = false
 		var verifiedIssuer = &Issuer{}
 		var verifiedCohort = int16(0)
-		for _, issuer := range *issuers {
+		for _, issuer := range issuers {
 			if !issuer.ExpiresAt.IsZero() && issuer.ExpiresAt.Before(time.Now()) {
 				continue
 			}

--- a/server/tokens.go
+++ b/server/tokens.go
@@ -89,7 +89,7 @@ func (c *Server) BlindedTokenIssuerHandlerV2(w http.ResponseWriter, r *http.Requ
 			}
 		}
 
-		issuer, appErr := c.GetLatestIssuer(issuerType, request.IssuerCohort)
+		issuer, appErr := c.GetLatestIssuer(r.Context(), issuerType, request.IssuerCohort)
 		if appErr != nil {
 			return appErr
 		}
@@ -125,7 +125,7 @@ func (c *Server) BlindedTokenIssuerHandlerV2(w http.ResponseWriter, r *http.Requ
 func (c *Server) blindedTokenIssuerHandler(w http.ResponseWriter, r *http.Request) *handlers.AppError {
 	var response blindedTokenIssueResponse
 	if issuerType := chi.URLParam(r, "type"); issuerType != "" {
-		issuer, appErr := c.GetLatestIssuer(issuerType, v1Cohort)
+		issuer, appErr := c.GetLatestIssuer(r.Context(), issuerType, v1Cohort)
 		if appErr != nil {
 			return appErr
 		}
@@ -284,7 +284,7 @@ func (c *Server) blindedTokenRedeemHandlerV3(w http.ResponseWriter, r *http.Requ
 func (c *Server) blindedTokenRedeemHandler(w http.ResponseWriter, r *http.Request) *handlers.AppError {
 	var response blindedTokenRedeemResponse
 	if issuerType := chi.URLParam(r, "type"); issuerType != "" {
-		issuers, appErr := c.getIssuers(issuerType)
+		issuers, appErr := c.getIssuers(r.Context(), issuerType)
 		if appErr != nil {
 			return appErr
 		}
@@ -378,7 +378,7 @@ func (c *Server) blindedTokenBulkRedeemHandler(w http.ResponseWriter, r *http.Re
 	for _, token := range request.Tokens {
 		// @TODO: this code seems to be from an old version - we use the `redeemTokenWithDB`, and we have no tests, so I
 		// assume that is no longer used, hence the usage of v1Cohort.
-		issuer, appErr := c.GetLatestIssuer(token.Issuer, v1Cohort)
+		issuer, appErr := c.GetLatestIssuer(r.Context(), token.Issuer, v1Cohort)
 
 		if appErr != nil {
 			_ = tx.Rollback()


### PR DESCRIPTION
This PR addresses retrieving issuer keys for a `v3Issuer`. In ads-serve we are querying the endpoint to retrieve all issuers for a given cohort. For each issuer retrieved, the code must also get the issuer key. Here I implemented a change to retrieve these keys in parallel. I used [Error Groups](https://pkg.go.dev/golang.org/x/sync/errgroup) to keep the functionality around errors how it was before (returning early if error). Also paired down the key getting into a shared function.

Other changes of note:
- `FetchAllIssuers` uses `fetchAllIssuers` under the hood after slight modification
- Query to get key uses already retrieved version value when fetching all issuers
- functions no longer return `*[]Issuer`, they return `[]Issuer` as slices are already pointers to underlying memory arrays and can be `nil`
- other go-isms
   - replaced empty array with nil slices
   - introduce context where possible for functions changed

#### TODO
- [X] Fix errors