### PR TITLE
Migration Annotation and Query Update

### DIFF
--- a/migrations/0007_issuers_v3.up.sql
+++ b/migrations/0007_issuers_v3.up.sql
@@ -53,6 +53,18 @@ from issuers
 where version = 2
 order by issuer_type, expires_at desc;
 
+-- For ads, specifically, 6 variations of the below command were run manually with
+-- issuer_cohort = 0 through 5
+-- insert into v3_issuers (
+--     issuer_id, issuer_type, created_at, expires_at, last_rotated_at, valid_from,
+--     buffer, days_out, overlap, issuer_cohort, redemption_repository, version, max_tokens)
+-- select distinct on (issuer_type)
+--     id, issuer_type || '_' || issuer_cohort as issuer_type, created_at, expires_at, rotated_at, created_at,
+--     1, 30, 7, issuer_cohort, 'dynamodb', version, max_tokens
+-- from issuers
+-- where version = 2 and issuer_cohort = 5
+-- order by issuer_type, expires_at desc;
+
 -- keys introduction
 insert into v3_issuer_keys (
     issuer_id, created_at, signing_key, cohort)
@@ -61,3 +73,13 @@ with
         select id, v3_issuers.issuer_id, issuers.created_at, signing_key, issuers.issuer_cohort from issuers left join v3_issuers on v3_issuers.issuer_type = issuers.issuer_type
     )
 select s1.issuer_id, s1.created_at, s1.signing_key, s1.issuer_cohort from s1;
+
+-- For ads, specifically, this modified keys introduction command was run manually to
+-- accomodate the modified issuer_type from the v2 migrations step
+-- insert into v3_issuer_keys (
+--     issuer_id, created_at, signing_key, cohort)
+-- with
+--     s1 as (
+--         select id, v3_issuers.issuer_id, issuers.created_at, signing_key, issuers.issuer_cohort from issuers left join v3_issuers on v3_issuers.issuer_type  = issuers.issuer_type || '_' || issuers.issuer_cohort
+--     )
+-- select s1.issuer_id, s1.created_at, s1.signing_key, s1.issuer_cohort from s1;

--- a/server/db.go
+++ b/server/db.go
@@ -342,7 +342,7 @@ func (c *Server) fetchIssuersByCohort(issuerType string, issuerCohort int16) (*[
 		&fetchedIssuers,
 		`SELECT i.*
 		FROM v3_issuers i join v3_issuer_keys k on (i.issuer_id=k.issuer_id)
-		WHERE i.issuer_type=$1 AND k.cohort=$2
+		WHERE i.issuer_type like $1 || '%' AND k.cohort=$2
 		ORDER BY i.expires_at DESC NULLS FIRST, i.created_at DESC`, issuerType, issuerCohort)
 	if err != nil {
 		c.Logger.Error("Failed to extract issuers from DB")


### PR DESCRIPTION
Annotate migration and update issuer select to tolerate new Ads issuers format. This is needed because Ads has not historically enforced `issuer_type` uniqueness.