### PR TITLE
Remove Unneeded Caching

### DIFF
--- a/server/issuers.go
+++ b/server/issuers.go
@@ -83,6 +83,7 @@ func (c *Server) GetLatestIssuerKafka(issuerType string, issuerCohort int16) (*I
 }
 
 // GetIssuers - get all issuers by issuer type
+// @TODO: This function is no longer needed. Delete.
 func (c *Server) GetIssuers(issuerType string) (*[]Issuer, error) {
 	issuers, err := c.getIssuers(issuerType)
 	if err != nil {
@@ -92,6 +93,7 @@ func (c *Server) GetIssuers(issuerType string) (*[]Issuer, error) {
 	return issuers, nil
 }
 
+// @TODO: This function is no longer needed. Delete.
 func (c *Server) getIssuers(issuerType string) (*[]Issuer, *handlers.AppError) {
 	issuer, err := c.fetchIssuers(issuerType)
 	if err != nil {

--- a/server/tokens.go
+++ b/server/tokens.go
@@ -281,6 +281,7 @@ func (c *Server) blindedTokenRedeemHandlerV3(w http.ResponseWriter, r *http.Requ
 	return handlers.RenderContent(r.Context(), response, w, http.StatusOK)
 }
 
+// @TODO: This function is no longer needed. Delete.
 func (c *Server) blindedTokenRedeemHandler(w http.ResponseWriter, r *http.Request) *handlers.AppError {
 	var response blindedTokenRedeemResponse
 	if issuerType := chi.URLParam(r, "type"); issuerType != "" {


### PR DESCRIPTION
We need to enable caching. However, there were caches being created within functions that would only be called if the cache had already missed at a higher level. These cache instances have been remove. Also, while going through the caching, some cases were discovered which expect non-unique issuer_types, which are no longer supported. They will continue to function for now, returning arrays of single issuers. However, these should be refactored to use unique issuer_types or removed altogether.