### PR TITLE
fix: issuer StartAt & EndAt are allowed to be nil

### DIFF
--- a/kafka/signed_token_redeem_handler.go
+++ b/kafka/signed_token_redeem_handler.go
@@ -99,10 +99,7 @@ func SignedTokenRedeemHandler(
 
 		for _, issuerKey := range issuer.Keys {
 			// Don't use keys outside their start/end dates
-			if issuerTimeIsNotValid(issuerKey.StartAt) {
-				continue
-			}
-			if issuerTimeIsNotValid(issuerKey.EndAt) {
+			if issuerTimeIsNotValid(issuerKey.StartAt, issuerKey.EndAt) {
 				continue
 			}
 
@@ -384,13 +381,16 @@ func SignedTokenRedeemHandler(
 	return nil
 }
 
-func issuerTimeIsNotValid(t *time.Time) bool {
+func issuerTimeIsNotValid(start *time.Time, end *time.Time) bool {
 	// Nil times are valid
-	if t == nil {
+	if start == nil && end == nil {
 		return false
 	}
 
-	return !t.IsZero() && t.After(time.Now())
+	now := time.Now()
+	startInvalid := start != nil && !start.IsZero() && start.After(now)
+	endInvalid := end != nil && !end.IsZero() && end.Before(now)
+	return startInvalid && endInvalid
 }
 
 // avroRedeemErrorResultFromError returns a ProcessingResult that is constructed from the

--- a/kafka/signed_token_redeem_handler.go
+++ b/kafka/signed_token_redeem_handler.go
@@ -382,15 +382,18 @@ func SignedTokenRedeemHandler(
 }
 
 func issuerTimeIsNotValid(start *time.Time, end *time.Time) bool {
-	// Nil times are valid
-	if start == nil && end == nil {
-		return false
+	if start != nil && end != nil {
+		now := time.Now()
+
+		startIsNotZeroAndAfterNow := !start.IsZero() && start.After(now)
+		endIsNotZeroAndBeforeNow := !end.IsZero() && end.Before(now)
+
+		return startIsNotZeroAndAfterNow || endIsNotZeroAndBeforeNow
 	}
 
-	now := time.Now()
-	startInvalid := start != nil && !start.IsZero() && start.After(now)
-	endInvalid := end != nil && !end.IsZero() && end.Before(now)
-	return startInvalid || endInvalid
+	// Both times being nil is valid
+	bothTimesAreNil := start == nil && end == nil
+	return !bothTimesAreNil
 }
 
 // avroRedeemErrorResultFromError returns a ProcessingResult that is constructed from the

--- a/kafka/signed_token_redeem_handler.go
+++ b/kafka/signed_token_redeem_handler.go
@@ -99,10 +99,10 @@ func SignedTokenRedeemHandler(
 
 		for _, issuerKey := range issuer.Keys {
 			// Don't use keys outside their start/end dates
-			if issuerKey.StartAt != nil && !issuerKey.StartAt.IsZero() && issuerKey.StartAt.After(time.Now()) {
+			if issuerTimeIsNotValid(issuerKey.StartAt) {
 				continue
 			}
-			if issuerKey.EndAt != nil && !issuerKey.EndAt.IsZero() && issuerKey.EndAt.Before(time.Now()) {
+			if issuerTimeIsNotValid(issuerKey.EndAt) {
 				continue
 			}
 
@@ -382,6 +382,15 @@ func SignedTokenRedeemHandler(
 	}
 
 	return nil
+}
+
+func issuerTimeIsNotValid(t *time.Time) bool {
+	// Nil times are valid
+	if t == nil {
+		return false
+	}
+
+	return !t.IsZero() && t.After(time.Now())
 }
 
 // avroRedeemErrorResultFromError returns a ProcessingResult that is constructed from the

--- a/kafka/signed_token_redeem_handler.go
+++ b/kafka/signed_token_redeem_handler.go
@@ -390,7 +390,7 @@ func issuerTimeIsNotValid(start *time.Time, end *time.Time) bool {
 	now := time.Now()
 	startInvalid := start != nil && !start.IsZero() && start.After(now)
 	endInvalid := end != nil && !end.IsZero() && end.Before(now)
-	return startInvalid && endInvalid
+	return startInvalid || endInvalid
 }
 
 // avroRedeemErrorResultFromError returns a ProcessingResult that is constructed from the


### PR DESCRIPTION
issuerKey is allowed to have a `null` StartAt or EndAt. 

Resolves issue where CBP was panicking when trying to check the date. 
Based on https://github.com/brave-intl/challenge-bypass-server/pull/526/files