### PR TITLE
fix: use issuerKey.SigningKey

### DIFF
--- a/kafka/signed_token_redeem_handler.go
+++ b/kafka/signed_token_redeem_handler.go
@@ -103,12 +103,7 @@ func SignedTokenRedeemHandler(
 				continue
 			}
 
-			signingKey := issuer.SigningKey
-			if signingKey == nil {
-				continue
-			}
-
-			// Only attempt token verification with the issuer that was provided.
+			signingKey := issuerKey.SigningKey
 			issuerPublicKey := signingKey.PublicKey()
 			marshaledPublicKey, mErr := issuerPublicKey.MarshalText()
 			// Unmarshalling failure is a data issue and is probably permanent.


### PR DESCRIPTION
Based on the original implementation

https://github.com/brave-intl/challenge-bypass-server/blob/8be5d66e81df5b91dfdf58234ad28d6d65d50a3b/kafka/signed_token_redeem_handler.go#L160-L162

It looks like the code should be `issuerKey.SigningKey`, not `issuer.SigningKey`