### PR TITLE
fix: handle unknown topic etc.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ docker-test:
 	--key-schema AttributeName=id,KeyType=HASH \
 	--billing-mode PAY_PER_REQUEST \
 	--table-name redemptions --endpoint-url http://dynamodb:8000 --region us-west-2 ) \
-	&& go test ./..."
+	&& go test -v ./..."
 
 docker-lint:
 	docker-compose -f docker-compose.yml -f docker-compose.dev.yml run --rm -p 2416:2416 challenge-bypass golangci-lint run

--- a/kafka/main_test.go
+++ b/kafka/main_test.go
@@ -1,0 +1,112 @@
+// Package kafka manages kafka interaction
+package kafka
+
+import (
+	"context"
+	"errors"
+	"sync/atomic"
+	"testing"
+
+	"github.com/rs/zerolog"
+	"github.com/segmentio/kafka-go"
+	"github.com/stretchr/testify/assert"
+)
+
+type testMessageReader struct {
+	fetch func() (kafka.Message, error)
+}
+
+func (r *testMessageReader) FetchMessage(ctx context.Context) (kafka.Message, error) {
+	return r.fetch()
+}
+
+func (r *testMessageReader) Stats() kafka.ReaderStats {
+	return kafka.ReaderStats{}
+}
+
+func TestProcessMessagesIntoBatchPipeline(t *testing.T) {
+	nopLog := zerolog.Nop()
+	t.Run("AbsentTopicClosesMsg", func(t *testing.T) {
+		t.Parallel()
+
+		batchPipeline := make(chan *MessageContext)
+
+		r := &testMessageReader{}
+		messageCounter := 0
+		r.fetch = func() (kafka.Message, error) {
+			messageCounter++
+			if messageCounter == 1 {
+				return kafka.Message{Topic: "absent"}, nil
+			}
+			// processMessagesIntoBatchPipeline never returns, so leak its
+			// goroutine via blocking here forever.
+			select {}
+		}
+		go processMessagesIntoBatchPipeline(context.Background(),
+			nil, r, batchPipeline, &nopLog)
+		msg := <-batchPipeline
+		assert.NotNil(t, msg)
+		<-msg.done
+		assert.Equal(t, "absent", msg.msg.Topic)
+
+		// Absent topic signals permanent error and the message should be
+		// committed, so msg.err must be nil.
+		assert.Nil(t, msg.err)
+	})
+
+	t.Run("OrderPreserved", func(t *testing.T) {
+		t.Parallel()
+
+		// The capacity of the pipeline. The code below posts double amount of
+		// messages.
+		N := 50
+		batchPipeline := make(chan *MessageContext, N)
+
+		r := &testMessageReader{}
+		messageCounter := 0
+		r.fetch = func() (kafka.Message, error) {
+			i := messageCounter
+			messageCounter++
+			if i < 2*N {
+				// processMessagesIntoBatchPipeline() does not touch
+				// Message.Partition, so use that to pass message number info to
+				// Processor below.
+				return kafka.Message{Topic: "topicA", Partition: i}, nil
+			}
+			select {} // block forever
+		}
+		atomicCounter := int32(N)
+		topicMappings := []TopicMapping{{
+			Topic: "topicA",
+			Processor: func(ctx context.Context, msg kafka.Message, logger *zerolog.Logger) error {
+				if msg.Partition < N {
+					// Make processor to post results in the reverse order of
+					// messages using a busy wait
+					for atomic.LoadInt32(&atomicCounter) != int32(msg.Partition+1) {
+					}
+					atomic.AddInt32(&atomicCounter, int32(-1))
+				}
+
+				if msg.Partition == 0 || msg.Partition == N {
+					return errors.New("error")
+				}
+				return nil
+			},
+		}}
+
+		go processMessagesIntoBatchPipeline(context.Background(),
+			topicMappings, r, batchPipeline, &nopLog)
+		for i := 0; i < 2*N; i++ {
+			msg := <-batchPipeline
+			assert.NotNil(t, msg)
+			<-msg.done
+			assert.Equal(t, "topicA", msg.msg.Topic)
+			assert.Equal(t, i, msg.msg.Partition)
+			if i == 0 || i == N {
+				assert.NotNil(t, msg.err)
+			} else {
+				assert.Nil(t, msg.err)
+			}
+		}
+	})
+}

--- a/kafka/signed_token_redeem_handler.go
+++ b/kafka/signed_token_redeem_handler.go
@@ -2,11 +2,13 @@ package kafka
 
 import (
 	"bytes"
+	"context"
 	"errors"
 	"fmt"
-	"github.com/brave-intl/challenge-bypass-server/model"
 	"strings"
 	"time"
+
+	"github.com/brave-intl/challenge-bypass-server/model"
 
 	crypto "github.com/brave-intl/challenge-bypass-ristretto-ffi"
 	avroSchema "github.com/brave-intl/challenge-bypass-server/avro/generated"
@@ -31,6 +33,7 @@ type SignedIssuerToken struct {
 }
 
 func SignedTokenRedeemHandler(
+	ctx context.Context,
 	msg kafka.Message,
 	producer *kafka.Writer,
 	server *cbpServer.Server,
@@ -41,7 +44,8 @@ func SignedTokenRedeemHandler(
 	tokenRedeemRequestSet, err := avroSchema.DeserializeRedeemRequestSet(bytes.NewReader(data))
 	if err != nil {
 		message := fmt.Sprintf("request %s: failed avro deserialization", tokenRedeemRequestSet.Request_id)
-		handlePermanentRedemptionError(
+		return handlePermanentRedemptionError(
+			ctx,
 			message,
 			err,
 			msg,
@@ -50,7 +54,6 @@ func SignedTokenRedeemHandler(
 			int32(avroSchema.RedeemResultStatusError),
 			log,
 		)
-		return nil
 	}
 
 	logger := log.With().Str("request_id", tokenRedeemRequestSet.Request_id).Logger()
@@ -62,7 +65,8 @@ func SignedTokenRedeemHandler(
 		// NOTE: When we start supporting multiple requests we will need to review
 		// errors and return values as well.
 		message := fmt.Sprintf("request %s: data array unexpectedly contained more than a single message. This array is intended to make future extension easier, but no more than a single value is currently expected", tokenRedeemRequestSet.Request_id)
-		handlePermanentRedemptionError(
+		return handlePermanentRedemptionError(
+			ctx,
 			message,
 			errors.New("multiple messages"),
 			msg,
@@ -71,7 +75,6 @@ func SignedTokenRedeemHandler(
 			int32(avroSchema.RedeemResultStatusError),
 			log,
 		)
-		return nil
 	}
 	issuers, err := server.FetchAllIssuers()
 	if err != nil {
@@ -79,7 +82,8 @@ func SignedTokenRedeemHandler(
 			return processingError
 		}
 		message := fmt.Sprintf("request %s: failed to fetch all issuers", tokenRedeemRequestSet.Request_id)
-		handlePermanentRedemptionError(
+		return handlePermanentRedemptionError(
+			ctx,
 			message,
 			err,
 			msg,
@@ -88,7 +92,6 @@ func SignedTokenRedeemHandler(
 			int32(avroSchema.RedeemResultStatusError),
 			log,
 		)
-		return nil
 	}
 
 	// Create a lookup for issuers & signing keys based on public key
@@ -110,7 +113,8 @@ func SignedTokenRedeemHandler(
 			// Unmarshalling failure is a data issue and is probably permanent.
 			if mErr != nil {
 				message := fmt.Sprintf("request %s: could not unmarshal issuer public key into text", tokenRedeemRequestSet.Request_id)
-				handlePermanentRedemptionError(
+				return handlePermanentRedemptionError(
+					ctx,
 					message,
 					err,
 					msg,
@@ -119,7 +123,6 @@ func SignedTokenRedeemHandler(
 					int32(avroSchema.RedeemResultStatusError),
 					log,
 				)
-				return nil
 			}
 
 			signedTokens[string(marshaledPublicKey)] = SignedIssuerToken{
@@ -169,7 +172,8 @@ func SignedTokenRedeemHandler(
 		// Unmarshaling failure is a data issue and is probably permanent.
 		if err != nil {
 			message := fmt.Sprintf("request %s: could not unmarshal text into preimage", tokenRedeemRequestSet.Request_id)
-			handlePermanentRedemptionError(
+			return handlePermanentRedemptionError(
+				ctx,
 				message,
 				err,
 				msg,
@@ -178,14 +182,14 @@ func SignedTokenRedeemHandler(
 				int32(avroSchema.RedeemResultStatusError),
 				log,
 			)
-			return nil
 		}
 		verificationSignature := crypto.VerificationSignature{}
 		err = verificationSignature.UnmarshalText([]byte(request.Signature))
 		// Unmarshaling failure is a data issue and is probably permanent.
 		if err != nil {
 			message := fmt.Sprintf("request %s: could not unmarshal text into verification signature", tokenRedeemRequestSet.Request_id)
-			handlePermanentRedemptionError(
+			return handlePermanentRedemptionError(
+				ctx,
 				message,
 				err,
 				msg,
@@ -194,7 +198,6 @@ func SignedTokenRedeemHandler(
 				int32(avroSchema.RedeemResultStatusError),
 				log,
 			)
-			return nil
 		}
 
 		if signedToken, ok := signedTokens[request.Public_key]; ok {
@@ -241,7 +244,8 @@ func SignedTokenRedeemHandler(
 				}
 			}
 			message := fmt.Sprintf("request %s: failed to check redemption equivalence", tokenRedeemRequestSet.Request_id)
-			handlePermanentRedemptionError(
+			return handlePermanentRedemptionError(
+				ctx,
 				message,
 				err,
 				msg,
@@ -250,7 +254,6 @@ func SignedTokenRedeemHandler(
 				int32(avroSchema.RedeemResultStatusError),
 				log,
 			)
-			return nil
 		}
 
 		// Continue if there is a duplicate
@@ -289,7 +292,8 @@ func SignedTokenRedeemHandler(
 							return err
 						}
 					}
-					handlePermanentRedemptionError(
+					return handlePermanentRedemptionError(
+						ctx,
 						message,
 						err,
 						msg,
@@ -298,7 +302,6 @@ func SignedTokenRedeemHandler(
 						int32(avroSchema.RedeemResultStatusError),
 						log,
 					)
-					return nil
 				}
 				logger.Error().Err(fmt.Errorf("request %s: duplicate redemption: %w",
 					tokenRedeemRequestSet.Request_id, err)).
@@ -351,7 +354,8 @@ func SignedTokenRedeemHandler(
 	err = resultSet.Serialize(&resultSetBuffer)
 	if err != nil {
 		message := fmt.Sprintf("request %s: failed to serialize result set", tokenRedeemRequestSet.Request_id)
-		handlePermanentRedemptionError(
+		return handlePermanentRedemptionError(
+			ctx,
 			message,
 			err,
 			msg,
@@ -360,10 +364,9 @@ func SignedTokenRedeemHandler(
 			int32(avroSchema.RedeemResultStatusError),
 			log,
 		)
-		return nil
 	}
 
-	err = Emit(producer, resultSetBuffer.Bytes(), log)
+	err = Emit(ctx, producer, resultSetBuffer.Bytes(), log)
 	if err != nil {
 		message := fmt.Sprintf(
 			"request %s: failed to emit results to topic %s",
@@ -392,16 +395,15 @@ func issuerTimeIsNotValid(start *time.Time, end *time.Time) bool {
 	return !bothTimesAreNil
 }
 
-// avroRedeemErrorResultFromError returns a ProcessingResult that is constructed from the
-// provided values.
+// avroRedeemErrorResultFromError returns a message to emit that is constructed
+// from the provided values.
 func avroRedeemErrorResultFromError(
 	message string,
 	msg kafka.Message,
-	producer *kafka.Writer,
 	requestID string,
 	redeemResultStatus int32,
 	logger *zerolog.Logger,
-) *ProcessingResult {
+) []byte {
 	redeemResult := avroSchema.RedeemResult{
 		Issuer_name:     "",
 		Issuer_cohort:   0,
@@ -416,22 +418,15 @@ func avroRedeemErrorResultFromError(
 	err := resultSet.Serialize(&resultSetBuffer)
 	if err != nil {
 		message := fmt.Sprintf("request %s: failed to serialize result set", requestID)
-		return &ProcessingResult{
-			Message:        []byte(message),
-			ResultProducer: producer,
-			RequestID:      requestID,
-		}
+		return []byte(message)
 	}
-	return &ProcessingResult{
-		Message:        resultSetBuffer.Bytes(),
-		ResultProducer: producer,
-		RequestID:      requestID,
-	}
+	return resultSetBuffer.Bytes()
 }
 
 // handleRedemptionError is a convenience function that executes a call pattern shared
 // when handling all errors in the redeem flow
 func handlePermanentRedemptionError(
+	ctx context.Context,
 	message string,
 	cause error,
 	msg kafka.Message,
@@ -439,17 +434,20 @@ func handlePermanentRedemptionError(
 	requestID string,
 	redeemResultStatus int32,
 	logger *zerolog.Logger,
-) {
+) error {
 	logger.Error().Err(cause).Msgf("encountered permanent redemption failure: %v", message)
-	processingResult := avroRedeemErrorResultFromError(
+	toEmit := avroRedeemErrorResultFromError(
 		message,
 		msg,
-		producer,
 		requestID,
 		int32(avroSchema.RedeemResultStatusError),
 		logger,
 	)
-	if err := Emit(producer, processingResult.Message, logger); err != nil {
+	if err := Emit(ctx, producer, toEmit, logger); err != nil {
 		logger.Error().Err(err).Msg("failed to emit")
 	}
+	// TODO: consider returning err here as failing to emit error should not
+	// commit messages the same way as failing to emit a success does not
+	// commit.
+	return nil
 }


### PR DESCRIPTION
Refactor processMessagesIntoBatchPipeline to ensure that it closes the message channel to signal that the message processing is ready including the case when the message topic does not match any of configured topics. For that move all processing of the message including the search for topic processors to runMessageProcessor() groutine and use defer to close the channel. That required to change the message channel to be of struct{} type and store the error in the message itself so a simple defer close(msg.done) can be used to cover both normal and error cases.

Provide unit tests for processMessagesIntoBatchPipeline that cover success and error paths.

Bound batchPipeline capacity by the number of CPU cores to avoid running too many CPU-intensive tasks in parallel.

Closes #702
Closes #703
Closes #704