### PR TITLE
fix: fix time drift between client and server when redeeming v3

### DIFF
--- a/kafka/signed_token_redeem_handler.go
+++ b/kafka/signed_token_redeem_handler.go
@@ -8,15 +8,16 @@ import (
 	"strings"
 	"time"
 
-	"github.com/brave-intl/challenge-bypass-server/model"
-
-	crypto "github.com/brave-intl/challenge-bypass-ristretto-ffi"
-	avroSchema "github.com/brave-intl/challenge-bypass-server/avro/generated"
-	"github.com/brave-intl/challenge-bypass-server/btd"
-	cbpServer "github.com/brave-intl/challenge-bypass-server/server"
-	"github.com/brave-intl/challenge-bypass-server/utils"
 	"github.com/rs/zerolog"
 	"github.com/segmentio/kafka-go"
+
+	crypto "github.com/brave-intl/challenge-bypass-ristretto-ffi"
+
+	avroSchema "github.com/brave-intl/challenge-bypass-server/avro/generated"
+	"github.com/brave-intl/challenge-bypass-server/btd"
+	"github.com/brave-intl/challenge-bypass-server/model"
+	cbpServer "github.com/brave-intl/challenge-bypass-server/server"
+	"github.com/brave-intl/challenge-bypass-server/utils"
 )
 
 /*
@@ -94,10 +95,12 @@ func SignedTokenRedeemHandler(
 		)
 	}
 
-	// Create a lookup for issuers & signing keys based on public key
+	// Create a lookup for issuers & signing keys based on public key.
 	signedTokens := make(map[string]SignedIssuerToken)
+	now := time.Now()
+
 	for _, issuer := range issuers {
-		if !issuer.ExpiresAtTime().IsZero() && issuer.ExpiresAtTime().Before(time.Now()) {
+		if issuer.HasExpired(now) {
 			continue
 		}
 

--- a/model/issuer.go
+++ b/model/issuer.go
@@ -1,12 +1,22 @@
 package model
 
 import (
+	"errors"
+	"time"
+
 	"github.com/google/uuid"
 	"github.com/lib/pq"
-	"time"
+
+	crypto "github.com/brave-intl/challenge-bypass-ristretto-ffi"
 )
 
-// Issuer of tokens
+var (
+	ErrInvalidIssuerType   = errors.New("model: invalid issuer type")
+	ErrInvalidIV3Key       = errors.New("model: issuer_v3: invalid key")
+	ErrIssuerV3NoCryptoKey = errors.New("model: issuer_v3: no crypto signing key for period")
+)
+
+// Issuer represents an issuer of tokens.
 type Issuer struct {
 	ID                   *uuid.UUID   `json:"id" db:"issuer_id"`
 	IssuerType           string       `json:"issuer_type" db:"issuer_type"`
@@ -26,11 +36,79 @@ type Issuer struct {
 	Keys                 []IssuerKeys `json:"keys" db:"-"`
 }
 
-func (iss *Issuer) ExpiresAtTime() time.Time {
-	var t time.Time
-	if !iss.ExpiresAt.Valid {
-		return t
+func (x *Issuer) ExpiresAtTime() time.Time {
+	if !x.ExpiresAt.Valid {
+		return time.Time{}
 	}
 
-	return iss.ExpiresAt.Time
+	return x.ExpiresAt.Time
+}
+
+func (x *Issuer) HasExpired(now time.Time) bool {
+	expt := x.ExpiresAtTime()
+
+	return !expt.IsZero() && expt.Before(now)
+}
+
+func (x *Issuer) FindSigningKeys(now time.Time) ([]*crypto.SigningKey, error) {
+	if x.Version != 3 {
+		return nil, ErrInvalidIssuerType
+	}
+
+	const leeway = 1 * time.Hour
+
+	keys, err := x.findActiveKeys(now, leeway)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(keys) == 0 {
+		return nil, nil
+	}
+
+	return parseSigningKeys(keys), nil
+}
+
+// findActiveKeys finds active keys in x.Keys that are active for time now.
+//
+// It searches for strictly matching key first, and places it at the first position of the result.
+// Then it searches for keys that match with leeway lw.
+// The strictly matching key is excluded from search with lw.
+func (x *Issuer) findActiveKeys(now time.Time, lw time.Duration) ([]*IssuerKeys, error) {
+	var result []*IssuerKeys
+
+	for i := range x.Keys {
+		active, err := x.Keys[i].isActiveV3(now, 0)
+		if err != nil {
+			return nil, err
+		}
+
+		if active {
+			result = append([]*IssuerKeys{&x.Keys[i]}, result...)
+			continue
+		}
+
+		activeLw, err := x.Keys[i].isActiveV3(now, lw)
+		if err != nil {
+			return nil, err
+		}
+
+		if activeLw {
+			result = append(result, &x.Keys[i])
+		}
+	}
+
+	return result, nil
+}
+
+func parseSigningKeys(keys []*IssuerKeys) []*crypto.SigningKey {
+	result := make([]*crypto.SigningKey, 0, len(keys))
+
+	for i := range keys {
+		if key := keys[i].CryptoSigningKey(); key != nil {
+			result = append(result, key)
+		}
+	}
+
+	return result
 }

--- a/model/issuer_keys.go
+++ b/model/issuer_keys.go
@@ -1,12 +1,14 @@
 package model
 
 import (
-	crypto "github.com/brave-intl/challenge-bypass-ristretto-ffi"
-	"github.com/google/uuid"
 	"time"
+
+	"github.com/google/uuid"
+
+	crypto "github.com/brave-intl/challenge-bypass-ristretto-ffi"
 )
 
-// IssuerKeys - an issuer that uses time based keys
+// IssuerKeys represents time-based keys.
 type IssuerKeys struct {
 	ID         *uuid.UUID `json:"id" db:"key_id"`
 	SigningKey []byte     `json:"-" db:"signing_key"`
@@ -18,12 +20,33 @@ type IssuerKeys struct {
 	EndAt      *time.Time `json:"end_at" db:"end_at"`
 }
 
-func (key *IssuerKeys) CryptoSigningKey() *crypto.SigningKey {
-	cryptoSigningKey := crypto.SigningKey{}
-	err := cryptoSigningKey.UnmarshalText(key.SigningKey)
-	if err != nil {
+func (x *IssuerKeys) CryptoSigningKey() *crypto.SigningKey {
+	result := &crypto.SigningKey{}
+	if err := result.UnmarshalText(x.SigningKey); err != nil {
 		return nil
 	}
 
-	return &cryptoSigningKey
+	return result
+}
+
+func (x *IssuerKeys) isActiveV3(now time.Time, lw time.Duration) (bool, error) {
+	if !x.isValidV3() {
+		return false, ErrInvalidIV3Key
+	}
+
+	start, end := *x.StartAt, *x.EndAt
+	if lw == 0 {
+		return isTimeWithin(start, end, now), nil
+	}
+
+	// Shift start/end earlier/later by lw, respectively.
+	return isTimeWithin(start.Add(-1*lw), end.Add(lw), now), nil
+}
+
+func (x *IssuerKeys) isValidV3() bool {
+	return x.StartAt != nil && x.EndAt != nil
+}
+
+func isTimeWithin(start, end, now time.Time) bool {
+	return now.After(start) && now.Before(end)
 }

--- a/model/issuer_keys_test.go
+++ b/model/issuer_keys_test.go
@@ -1,0 +1,201 @@
+package model
+
+import (
+	"testing"
+	"time"
+
+	should "github.com/stretchr/testify/assert"
+	must "github.com/stretchr/testify/require"
+)
+
+func TestIssuerKeys_isActiveV3(t *testing.T) {
+	type tcGiven struct {
+		key *IssuerKeys
+		now time.Time
+		lw  time.Duration
+	}
+
+	type tcExpected struct {
+		val bool
+		err error
+	}
+
+	type testCase struct {
+		name  string
+		given tcGiven
+		exp   tcExpected
+	}
+
+	tests := []testCase{
+		{
+			name: "invalid_v3",
+			given: tcGiven{
+				key: &IssuerKeys{},
+				now: time.Date(2024, time.January, 1, 0, 0, 1, 0, time.UTC),
+				lw:  1 * time.Hour,
+			},
+			exp: tcExpected{err: ErrInvalidIV3Key},
+		},
+
+		{
+			name: "zero_leeway",
+			given: tcGiven{
+				key: &IssuerKeys{
+					StartAt: ptrTo(time.Date(2023, time.December, 31, 0, 0, 1, 0, time.UTC)),
+					EndAt:   ptrTo(time.Date(2024, time.January, 2, 0, 0, 1, 0, time.UTC)),
+				},
+				now: time.Date(2024, time.January, 1, 0, 0, 1, 0, time.UTC),
+			},
+			exp: tcExpected{val: true},
+		},
+
+		{
+			name: "leeway_1hour",
+			given: tcGiven{
+				key: &IssuerKeys{
+					StartAt: ptrTo(time.Date(2023, time.December, 31, 0, 0, 1, 0, time.UTC)),
+					EndAt:   ptrTo(time.Date(2024, time.January, 2, 0, 0, 1, 0, time.UTC)),
+				},
+				now: time.Date(2024, time.January, 2, 0, 0, 1, 0, time.UTC),
+				lw:  1 * time.Hour,
+			},
+			exp: tcExpected{val: true},
+		},
+	}
+
+	for i := range tests {
+		tc := tests[i]
+
+		t.Run(tc.name, func(t *testing.T) {
+			actual, err := tc.given.key.isActiveV3(tc.given.now, tc.given.lw)
+			must.Equal(t, tc.exp.err, err)
+
+			should.Equal(t, tc.exp.val, actual)
+		})
+	}
+}
+
+func TestIssuerKeys_isValidV3(t *testing.T) {
+	type testCase struct {
+		name  string
+		given *IssuerKeys
+		exp   bool
+	}
+
+	tests := []testCase{
+		{
+			name:  "invalid_both",
+			given: &IssuerKeys{},
+		},
+
+		{
+			name: "invalid_end",
+			given: &IssuerKeys{
+				StartAt: ptrTo(time.Date(2023, time.December, 31, 0, 0, 1, 0, time.UTC)),
+			},
+		},
+
+		{
+			name: "invalid_start",
+			given: &IssuerKeys{
+				EndAt: ptrTo(time.Date(2024, time.January, 2, 0, 0, 1, 0, time.UTC)),
+			},
+		},
+
+		{
+			name: "valid",
+			given: &IssuerKeys{
+				StartAt: ptrTo(time.Date(2023, time.December, 31, 0, 0, 1, 0, time.UTC)),
+				EndAt:   ptrTo(time.Date(2024, time.January, 2, 0, 0, 1, 0, time.UTC)),
+			},
+			exp: true,
+		},
+	}
+
+	for i := range tests {
+		tc := tests[i]
+
+		t.Run(tc.name, func(t *testing.T) {
+			actual := tc.given.isValidV3()
+			should.Equal(t, tc.exp, actual)
+		})
+	}
+}
+
+func TestIsTimeWithin(t *testing.T) {
+	type tcGiven struct {
+		start time.Time
+		end   time.Time
+		now   time.Time
+	}
+
+	type testCase struct {
+		name  string
+		given tcGiven
+		exp   bool
+	}
+
+	tests := []testCase{
+		{
+			name:  "zero_all",
+			given: tcGiven{},
+		},
+
+		{
+			name: "zero_start_end",
+			given: tcGiven{
+				now: time.Date(2024, time.January, 1, 0, 0, 1, 0, time.UTC),
+			},
+		},
+
+		{
+			name: "zero_start_now",
+			given: tcGiven{
+				end: time.Date(2024, time.January, 2, 0, 0, 1, 0, time.UTC),
+			},
+		},
+
+		{
+			name: "zero_now_end",
+			given: tcGiven{
+				start: time.Date(2023, time.December, 31, 0, 0, 1, 0, time.UTC),
+			},
+		},
+
+		{
+			name: "zero_now",
+			given: tcGiven{
+				start: time.Date(2023, time.December, 31, 0, 0, 1, 0, time.UTC),
+				end:   time.Date(2024, time.January, 2, 0, 0, 1, 0, time.UTC),
+			},
+		},
+
+		{
+			name: "invalid_inverse",
+			given: tcGiven{
+				start: time.Date(2024, time.January, 2, 0, 0, 1, 0, time.UTC),
+				end:   time.Date(2023, time.December, 31, 0, 0, 1, 0, time.UTC),
+				now:   time.Date(2024, time.January, 1, 0, 0, 1, 0, time.UTC),
+			},
+		},
+
+		{
+			name: "valid",
+			given: tcGiven{
+				start: time.Date(2023, time.December, 31, 0, 0, 1, 0, time.UTC),
+				end:   time.Date(2024, time.January, 2, 0, 0, 1, 0, time.UTC),
+				now:   time.Date(2024, time.January, 1, 0, 0, 1, 0, time.UTC),
+			},
+			exp: true,
+		},
+	}
+
+	for i := range tests {
+		tc := tests[i]
+
+		t.Run(tc.name, func(t *testing.T) {
+			actual := isTimeWithin(tc.given.start, tc.given.end, tc.given.now)
+			should.Equal(t, tc.exp, actual)
+		})
+	}
+}

--- a/model/issuer_test.go
+++ b/model/issuer_test.go
@@ -1,0 +1,409 @@
+package model
+
+import (
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/lib/pq"
+	should "github.com/stretchr/testify/assert"
+	must "github.com/stretchr/testify/require"
+
+	crypto "github.com/brave-intl/challenge-bypass-ristretto-ffi"
+)
+
+func TestIssuer_HasExpired(t *testing.T) {
+	type tcGiven struct {
+		issuer *Issuer
+		now    time.Time
+	}
+
+	type testCase struct {
+		name  string
+		given tcGiven
+		exp   bool
+	}
+
+	tests := []testCase{
+		{
+			name: "expires_at_zero",
+			given: tcGiven{
+				issuer: &Issuer{
+					ID: ptrTo(uuid.MustParse("f100ded0-0000-4000-a000-000000000000")),
+				},
+				now: time.Date(2024, time.January, 1, 0, 0, 1, 0, time.UTC),
+			},
+		},
+
+		{
+			name: "expires_at_same",
+			given: tcGiven{
+				issuer: &Issuer{
+					ID: ptrTo(uuid.MustParse("f100ded0-0000-4000-a000-000000000000")),
+					ExpiresAt: pq.NullTime{
+						Time:  time.Date(2024, time.January, 1, 0, 0, 1, 0, time.UTC),
+						Valid: true,
+					},
+				},
+				now: time.Date(2024, time.January, 1, 0, 0, 1, 0, time.UTC),
+			},
+		},
+
+		{
+			name: "expires_at_after",
+			given: tcGiven{
+				issuer: &Issuer{
+					ID: ptrTo(uuid.MustParse("f100ded0-0000-4000-a000-000000000000")),
+					ExpiresAt: pq.NullTime{
+						Time:  time.Date(2024, time.January, 2, 0, 0, 1, 0, time.UTC),
+						Valid: true,
+					},
+				},
+				now: time.Date(2024, time.January, 1, 0, 0, 1, 0, time.UTC),
+			},
+		},
+
+		{
+			name: "expires_at_before",
+			given: tcGiven{
+				issuer: &Issuer{
+					ID: ptrTo(uuid.MustParse("f100ded0-0000-4000-a000-000000000000")),
+					ExpiresAt: pq.NullTime{
+						Time:  time.Date(2023, time.December, 31, 23, 59, 59, 0, time.UTC),
+						Valid: true,
+					},
+				},
+				now: time.Date(2024, time.January, 1, 0, 0, 1, 0, time.UTC),
+			},
+			exp: true,
+		},
+	}
+
+	for i := range tests {
+		tc := tests[i]
+
+		t.Run(tc.name, func(t *testing.T) {
+			actual := tc.given.issuer.HasExpired(tc.given.now)
+			should.Equal(t, tc.exp, actual)
+		})
+	}
+}
+
+func TestFindSigningKeys(t *testing.T) {
+	type tcGiven struct {
+		issuer *Issuer
+		now    time.Time
+	}
+
+	type tcExpected struct {
+		num int
+		err error
+	}
+
+	type testCase struct {
+		name  string
+		given tcGiven
+		exp   tcExpected
+	}
+
+	tests := []testCase{
+		{
+			name: "not_v3",
+			given: tcGiven{
+				issuer: &Issuer{Version: 2},
+				now:    time.Date(2024, time.January, 1, 1, 0, 1, 0, time.UTC),
+			},
+			exp: tcExpected{err: ErrInvalidIssuerType},
+		},
+
+		{
+			name: "invalid_key_both_times",
+			given: tcGiven{
+				issuer: &Issuer{
+					Version: 3,
+					Keys:    []IssuerKeys{{}},
+				},
+				now: time.Date(2024, time.January, 1, 1, 0, 1, 0, time.UTC),
+			},
+			exp: tcExpected{err: ErrInvalidIV3Key},
+		},
+
+		{
+			name: "valid_key_inactive",
+			given: tcGiven{
+				issuer: &Issuer{
+					Version: 3,
+					Keys: []IssuerKeys{
+						{
+							StartAt: ptrTo(time.Date(2024, time.January, 1, 0, 0, 1, 0, time.UTC)),
+							EndAt:   ptrTo(time.Date(2024, time.January, 2, 0, 0, 1, 0, time.UTC)),
+						},
+					},
+				},
+				now: time.Date(2023, time.December, 31, 0, 0, 1, 0, time.UTC),
+			},
+		},
+
+		{
+			name: "valid_key_active",
+			given: tcGiven{
+				issuer: &Issuer{
+					Version: 3,
+					Keys: []IssuerKeys{
+						{
+							SigningKey: mustRandomSigningKey(),
+							StartAt:    ptrTo(time.Date(2024, time.January, 1, 0, 0, 1, 0, time.UTC)),
+							EndAt:      ptrTo(time.Date(2024, time.January, 2, 0, 0, 1, 0, time.UTC)),
+						},
+					},
+				},
+				now: time.Date(2024, time.January, 1, 1, 0, 1, 0, time.UTC),
+			},
+			exp: tcExpected{num: 1},
+		},
+	}
+
+	for i := range tests {
+		tc := tests[i]
+
+		t.Run(tc.name, func(t *testing.T) {
+			actual, err := tc.given.issuer.FindSigningKeys(tc.given.now)
+			must.Equal(t, tc.exp.err, err)
+
+			if tc.exp.err != nil {
+				return
+			}
+
+			should.Equal(t, tc.exp.num, len(actual))
+		})
+	}
+}
+
+func TestIssuer_findActiveKeys(t *testing.T) {
+	type tcGiven struct {
+		issuer *Issuer
+		now    time.Time
+		lw     time.Duration
+	}
+
+	type tcExpected struct {
+		result []*IssuerKeys
+		err    error
+	}
+
+	type testCase struct {
+		name  string
+		given tcGiven
+		exp   tcExpected
+	}
+
+	tests := []testCase{
+		{
+			name: "empty",
+			given: tcGiven{
+				issuer: &Issuer{},
+				now:    time.Date(2024, time.January, 1, 0, 0, 1, 0, time.UTC),
+			},
+		},
+
+		{
+			name: "invalid_key",
+			given: tcGiven{
+				issuer: &Issuer{
+					Version: 3,
+					Keys:    []IssuerKeys{{}},
+				},
+				now: time.Date(2024, time.January, 1, 0, 0, 1, 0, time.UTC),
+			},
+			exp: tcExpected{err: ErrInvalidIV3Key},
+		},
+
+		{
+			name: "valid_key_inactive",
+			given: tcGiven{
+				issuer: &Issuer{
+					Version: 3,
+					Keys: []IssuerKeys{
+						{
+							StartAt: ptrTo(time.Date(2024, time.January, 1, 0, 0, 1, 0, time.UTC)),
+							EndAt:   ptrTo(time.Date(2024, time.January, 2, 0, 0, 1, 0, time.UTC)),
+						},
+					},
+				},
+				now: time.Date(2023, time.December, 31, 0, 0, 1, 0, time.UTC),
+			},
+		},
+
+		{
+			name: "valid_key_active",
+			given: tcGiven{
+				issuer: &Issuer{
+					Version: 3,
+					Keys: []IssuerKeys{
+						{
+							StartAt: ptrTo(time.Date(2024, time.January, 1, 0, 0, 1, 0, time.UTC)),
+							EndAt:   ptrTo(time.Date(2024, time.January, 2, 0, 0, 1, 0, time.UTC)),
+						},
+					},
+				},
+				now: time.Date(2024, time.January, 1, 1, 0, 1, 0, time.UTC),
+			},
+			exp: tcExpected{
+				result: []*IssuerKeys{
+					{
+						StartAt: ptrTo(time.Date(2024, time.January, 1, 0, 0, 1, 0, time.UTC)),
+						EndAt:   ptrTo(time.Date(2024, time.January, 2, 0, 0, 1, 0, time.UTC)),
+					},
+				},
+			},
+		},
+
+		{
+			name: "valid_key_inactive_leeway",
+			given: tcGiven{
+				issuer: &Issuer{
+					Version: 3,
+					Keys: []IssuerKeys{
+						{
+							StartAt: ptrTo(time.Date(2024, time.January, 1, 0, 0, 1, 0, time.UTC)),
+							EndAt:   ptrTo(time.Date(2024, time.January, 2, 0, 0, 1, 0, time.UTC)),
+						},
+					},
+				},
+				now: time.Date(2023, time.December, 31, 23, 30, 1, 0, time.UTC),
+				lw:  1 * time.Hour,
+			},
+			exp: tcExpected{
+				result: []*IssuerKeys{
+					{
+						StartAt: ptrTo(time.Date(2024, time.January, 1, 0, 0, 1, 0, time.UTC)),
+						EndAt:   ptrTo(time.Date(2024, time.January, 2, 0, 0, 1, 0, time.UTC)),
+					},
+				},
+			},
+		},
+
+		{
+			name: "evq_strict_b_leeway_a",
+			given: tcGiven{
+				issuer: &Issuer{
+					Version: 3,
+					Keys: []IssuerKeys{
+						{
+							SigningKey: []byte(`key_a`),
+							StartAt:    ptrTo(time.Date(2024, time.May, 23, 0, 0, 0, 0, time.UTC)),
+							EndAt:      ptrTo(time.Date(2024, time.May, 24, 0, 0, 0, 0, time.UTC)),
+						},
+
+						{
+							SigningKey: []byte(`key_b`),
+							StartAt:    ptrTo(time.Date(2024, time.May, 24, 0, 0, 0, 0, time.UTC)),
+							EndAt:      ptrTo(time.Date(2024, time.May, 25, 0, 0, 0, 0, time.UTC)),
+						},
+
+						{
+							SigningKey: []byte(`key_c`),
+							StartAt:    ptrTo(time.Date(2024, time.May, 25, 0, 0, 0, 0, time.UTC)),
+							EndAt:      ptrTo(time.Date(2024, time.May, 26, 0, 0, 0, 0, time.UTC)),
+						},
+					},
+				},
+				now: time.Date(2024, time.May, 24, 0, 52, 25, 0, time.UTC),
+				lw:  1 * time.Hour,
+			},
+			exp: tcExpected{
+				result: []*IssuerKeys{
+					{
+						SigningKey: []byte(`key_b`),
+						StartAt:    ptrTo(time.Date(2024, time.May, 24, 0, 0, 0, 0, time.UTC)),
+						EndAt:      ptrTo(time.Date(2024, time.May, 25, 0, 0, 0, 0, time.UTC)),
+					},
+
+					{
+						SigningKey: []byte(`key_a`),
+						StartAt:    ptrTo(time.Date(2024, time.May, 23, 0, 0, 0, 0, time.UTC)),
+						EndAt:      ptrTo(time.Date(2024, time.May, 24, 0, 0, 0, 0, time.UTC)),
+					},
+				},
+			},
+		},
+
+		{
+			name: "evq_strict_b_leeway_c",
+			given: tcGiven{
+				issuer: &Issuer{
+					Version: 3,
+					Keys: []IssuerKeys{
+						{
+							SigningKey: []byte(`key_a`),
+							StartAt:    ptrTo(time.Date(2024, time.May, 23, 0, 0, 0, 0, time.UTC)),
+							EndAt:      ptrTo(time.Date(2024, time.May, 24, 0, 0, 0, 0, time.UTC)),
+						},
+
+						{
+							SigningKey: []byte(`key_b`),
+							StartAt:    ptrTo(time.Date(2024, time.May, 24, 0, 0, 0, 0, time.UTC)),
+							EndAt:      ptrTo(time.Date(2024, time.May, 25, 0, 0, 0, 0, time.UTC)),
+						},
+
+						{
+							SigningKey: []byte(`key_c`),
+							StartAt:    ptrTo(time.Date(2024, time.May, 25, 0, 0, 0, 0, time.UTC)),
+							EndAt:      ptrTo(time.Date(2024, time.May, 26, 0, 0, 0, 0, time.UTC)),
+						},
+					},
+				},
+				now: time.Date(2024, time.May, 24, 23, 52, 25, 0, time.UTC),
+				lw:  1 * time.Hour,
+			},
+			exp: tcExpected{
+				result: []*IssuerKeys{
+					{
+						SigningKey: []byte(`key_b`),
+						StartAt:    ptrTo(time.Date(2024, time.May, 24, 0, 0, 0, 0, time.UTC)),
+						EndAt:      ptrTo(time.Date(2024, time.May, 25, 0, 0, 0, 0, time.UTC)),
+					},
+
+					{
+						SigningKey: []byte(`key_c`),
+						StartAt:    ptrTo(time.Date(2024, time.May, 25, 0, 0, 0, 0, time.UTC)),
+						EndAt:      ptrTo(time.Date(2024, time.May, 26, 0, 0, 0, 0, time.UTC)),
+					},
+				},
+			},
+		},
+	}
+
+	for i := range tests {
+		tc := tests[i]
+
+		t.Run(tc.name, func(t *testing.T) {
+			actual, err := tc.given.issuer.findActiveKeys(tc.given.now, tc.given.lw)
+			must.Equal(t, tc.exp.err, err)
+
+			if tc.exp.err != nil {
+				return
+			}
+
+			should.Equal(t, tc.exp.result, actual)
+		})
+	}
+}
+
+func ptrTo[T any](v T) *T {
+	return &v
+}
+
+func mustRandomSigningKey() []byte {
+	key, err := crypto.RandomSigningKey()
+	if err != nil {
+		panic(err)
+	}
+
+	data, err := key.MarshalText()
+	if err != nil {
+		panic(err)
+	}
+
+	return data
+}

--- a/server/issuers.go
+++ b/server/issuers.go
@@ -4,19 +4,21 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
-	"github.com/brave-intl/challenge-bypass-server/model"
 	"net/http"
 	"os"
 	"time"
+
+	"github.com/go-chi/chi"
+	"github.com/lib/pq"
+	"github.com/pressly/lg"
+	"github.com/sirupsen/logrus"
 
 	"github.com/brave-intl/bat-go/libs/closers"
 	"github.com/brave-intl/bat-go/libs/handlers"
 	"github.com/brave-intl/bat-go/libs/middleware"
 	crypto "github.com/brave-intl/challenge-bypass-ristretto-ffi"
-	"github.com/go-chi/chi"
-	"github.com/lib/pq"
-	"github.com/pressly/lg"
-	"github.com/sirupsen/logrus"
+
+	"github.com/brave-intl/challenge-bypass-server/model"
 )
 
 type issuerResponse struct {
@@ -369,8 +371,8 @@ func (c *Server) issuerCreateHandlerV1(w http.ResponseWriter, r *http.Request) *
 
 func makeIssuerResponse(iss *model.Issuer) issuerResponse {
 	expiresAt := ""
-	if !iss.ExpiresAtTime().IsZero() {
-		expiresAt = iss.ExpiresAtTime().Format(time.RFC3339)
+	if expt := iss.ExpiresAtTime(); !expt.IsZero() {
+		expiresAt = expt.Format(time.RFC3339)
 	}
 
 	// Last key in array is the valid one

--- a/server/tokens_test.go
+++ b/server/tokens_test.go
@@ -1,0 +1,56 @@
+package server
+
+import (
+	"testing"
+
+	should "github.com/stretchr/testify/assert"
+
+	crypto "github.com/brave-intl/challenge-bypass-ristretto-ffi"
+)
+
+func TestBlindedTokenRedeemRequest_isEmpty(t *testing.T) {
+	tests := []struct {
+		name  string
+		given *blindedTokenRedeemRequest
+		exp   bool
+	}{
+		{
+			name: "no_token_preimage",
+			given: &blindedTokenRedeemRequest{
+				Signature: &crypto.VerificationSignature{},
+			},
+			exp: true,
+		},
+
+		{
+			name: "no_signature",
+			given: &blindedTokenRedeemRequest{
+				TokenPreimage: &crypto.TokenPreimage{},
+			},
+			exp: true,
+		},
+
+		{
+			name:  "no_token_preimage_no_signature",
+			given: &blindedTokenRedeemRequest{},
+			exp:   true,
+		},
+
+		{
+			name: "valid",
+			given: &blindedTokenRedeemRequest{
+				TokenPreimage: &crypto.TokenPreimage{},
+				Signature:     &crypto.VerificationSignature{},
+			},
+		},
+	}
+
+	for i := range tests {
+		tc := tests[i]
+
+		t.Run(tc.name, func(t *testing.T) {
+			actual := tc.given.isEmpty()
+			should.Equal(t, tc.exp, actual)
+		})
+	}
+}


### PR DESCRIPTION
This PR adds a 1 hour leeway to the check for issuer v3 signing key, as occasionally clients might fail if requests come through around the time of key rotation.

It also fixes a bug in the v3 redemption handler where issuer expiry check would never work – it mistakenly required the expiry time be both zero and after now at the same time, which was clearly a mistake (as anywhere else that check requires the time to not be zero).

Additionally, the PR offers small refactors to improve readability and maintainability, as well as some test coverage.

For more details, please see the linked issue.