### PR TITLE
Move Query Template Out of Shared Method

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ docker-dev:
 	docker-compose -f docker-compose.yml -f docker-compose.dev.yml run --rm -p 2416:2416 challenge-bypass /bin/bash
 
 docker-test:
-	docker-compose -f docker-compose.yml -f docker-compose.dev.yml run --rm -p 2416:2416 challenge-bypass bash -c \
+	docker compose -f docker-compose.yml -f docker-compose.dev.yml run --rm -p 2416:2416 challenge-bypass bash -c \
 	"(aws dynamodb delete-table \
 	--table-name redemptions --endpoint-url http://dynamodb:8000 --region us-west-2  || \
 	aws dynamodb create-table \


### PR DESCRIPTION
The `like` segment of the modified query is causing issues for the grants deployment of this service. To resolve, move the query template string out into the already-forked implementations to permit different treatments of this query.