### PR TITLE
Revert Debugging Changes

### DIFF
--- a/main.go
+++ b/main.go
@@ -26,7 +26,7 @@ func main() {
 	)
 
 	serverCtx, logger := server.SetupLogger(context.Background())
-	logLevel = zerolog.TraceLevel
+	logLevel = zerolog.WarnLevel
 	if os.Getenv("ENV") == "local" {
 		logLevel = zerolog.TraceLevel
 	}
@@ -71,17 +71,6 @@ func main() {
 
 	zeroLogger.Trace().Msg("Persistence and cron jobs initialized")
 
-	zeroLogger.Trace().Msg("Initializing API server")
-	go func() {
-		err = srv.ListenAndServe(serverCtx, logger)
-		if err != nil {
-			zeroLogger.Error().Err(err).Msg("Failed to initialize API server")
-			raven.CaptureErrorAndWait(err, nil)
-			logger.Panic(err)
-			return
-		}
-	}()
-
 	// add profiling flag to enable profiling routes
 	if os.Getenv("PPROF_ENABLE") != "" {
 		zeroLogger.Trace().Msg("Enabling PPROF")
@@ -99,8 +88,19 @@ func main() {
 
 	if os.Getenv("KAFKA_ENABLED") != "false" {
 		zeroLogger.Trace().Msg("Spawning Kafka goroutine")
-		startKafka(srv, zeroLogger)
+		go startKafka(srv, zeroLogger)
 	}
+
+	zeroLogger.Trace().Msg("Initializing API server")
+	go func() {
+		err = srv.ListenAndServe(serverCtx, logger)
+		if err != nil {
+			zeroLogger.Error().Err(err).Msg("Failed to initialize API server")
+			raven.CaptureErrorAndWait(err, nil)
+			logger.Panic(err)
+			return
+		}
+	}()
 }
 
 func startKafka(srv server.Server, zeroLogger *zerolog.Logger) {

--- a/main.go
+++ b/main.go
@@ -92,15 +92,13 @@ func main() {
 	}
 
 	zeroLogger.Trace().Msg("Initializing API server")
-	go func() {
-		err = srv.ListenAndServe(serverCtx, logger)
-		if err != nil {
-			zeroLogger.Error().Err(err).Msg("Failed to initialize API server")
-			raven.CaptureErrorAndWait(err, nil)
-			logger.Panic(err)
-			return
-		}
-	}()
+	err = srv.ListenAndServe(serverCtx, logger)
+	if err != nil {
+		zeroLogger.Error().Err(err).Msg("Failed to initialize API server")
+		raven.CaptureErrorAndWait(err, nil)
+		logger.Panic(err)
+		return
+	}
 }
 
 func startKafka(srv server.Server, zeroLogger *zerolog.Logger) {

--- a/server/server.go
+++ b/server/server.go
@@ -14,6 +14,7 @@ import (
 	"github.com/brave-intl/bat-go/libs/middleware"
 	"github.com/go-chi/chi"
 	chiware "github.com/go-chi/chi/middleware"
+	"github.com/go-chi/httplog"
 	"github.com/jmoiron/sqlx"
 	"github.com/pressly/lg"
 	"github.com/prometheus/client_golang/prometheus"
@@ -155,10 +156,10 @@ func (c *Server) setupRouter(ctx context.Context, logger *logrus.Logger) (contex
 	r.Use(chiware.Timeout(60 * time.Second))
 	r.Use(middleware.BearerToken)
 	// Also handles panic recovery
-	//chiLogger := httplog.NewLogger("cbp-request-logs", httplog.Options{
-	//	JSON: true,
-	//})
-	//r.Use(logMiddlewareOmittingPath("/metrics", httplog.RequestLogger(chiLogger)))
+	chiLogger := httplog.NewLogger("cbp-request-logs", httplog.Options{
+		JSON: true,
+	})
+	r.Use(httplog.RequestLogger(chiLogger))
 
 	c.Logger = logger
 
@@ -180,23 +181,6 @@ func (c *Server) setupRouter(ctx context.Context, logger *logrus.Logger) (contex
 
 	return ctx, r
 }
-
-//func logMiddlewareOmittingPath(
-//	path string,
-//	middleware func(http.Handler) http.Handler,
-//) func(http.Handler) http.Handler {
-//	return func(next http.Handler) http.Handler {
-//		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-//			if r.URL.Path == path {
-//				// Skip the logging middleware for the specified path
-//				next.ServeHTTP(w, r)
-//				return
-//			}
-//			// Apply the middleware for other paths
-//			middleware(next).ServeHTTP(w, r)
-//		})
-//	}
-//}
 
 // ListenAndServe listen to ports and mount handlers
 func (c *Server) ListenAndServe(ctx context.Context, logger *logrus.Logger) error {


### PR DESCRIPTION
As part of the recent investigation some changes were introduced that expand the scope of this release. They've been reverted as follows:

Fully reverted:
- #789 
- #790 

Partially reverted:
- #791: Reverted log level change and removed commented changes to API logging. `kafkaGo` renaming kept, as it fixes a compilation warning.

PR #792 is a simple improvement worth leaving in.

The result of this reversion is that the master head contains the IAM kafka change, the required security upgrades and associated changes, as well as the error handling and renaming mentioned above. 