### PR TITLE
Add Prometheus Metrics

### DIFF
--- a/kafka/main.go
+++ b/kafka/main.go
@@ -15,6 +15,7 @@ import (
 	batgo_kafka "github.com/brave-intl/bat-go/libs/kafka"
 	"github.com/brave-intl/challenge-bypass-server/server"
 	uuid "github.com/google/uuid"
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/rs/zerolog"
 	kafkaGo "github.com/segmentio/kafka-go"
 	"github.com/segmentio/kafka-go/sasl/aws_msk_iam_v2"
@@ -45,6 +46,48 @@ type MessageContext struct {
 	msg  kafkaGo.Message
 }
 
+var (
+	tokenIssuanceRequestTotal = prometheus.NewCounter(prometheus.CounterOpts{
+		Name: "cbp_token_issuance_request_total",
+		Help: "Number of requests for new tokens",
+	})
+	tokenIssuanceFailureTotal = prometheus.NewCounter(prometheus.CounterOpts{
+		Name: "cbp_token_issuance_failure_total",
+		Help: "Number of token requests that failed",
+	})
+	tokenRedeemRequestTotal = prometheus.NewCounter(prometheus.CounterOpts{
+		Name: "cbp_token_redeem_request_total",
+		Help: "Number of requests for token redemption",
+	})
+	tokenRedeemFailureTotal = prometheus.NewCounter(prometheus.CounterOpts{
+		Name: "cbp_token_redeem_failure_total",
+		Help: "Number of tokens redeemed",
+	})
+	duplicateRedemptionTotal = prometheus.NewCounter(prometheus.CounterOpts{
+		Name: "cbp_duplicate_redemption_total",
+		Help: `Number of tokens requested for redemption after already being
+		processed, but with modified request information. This is malicious and
+		should be rare.`,
+	})
+	idempotentRedemptionTotal = prometheus.NewCounter(prometheus.CounterOpts{
+		Name: "cbp_idempotent_redemption_total",
+		Help: `Number of identical tokens requested for redemption. This is an
+		innocent retry.`,
+	})
+	rebootFromPanicTotal = prometheus.NewCounter(prometheus.CounterOpts{
+		Name: "cbp_reboot_from_panic_total",
+		Help: `There is a case where the current expected behavior is to panic
+		to avoid any chance of committing a bad offset to Kafka. This counts
+		that case.`,
+	})
+	kafkaErrorTotal = prometheus.NewCounter(prometheus.CounterOpts{
+		Name: "cbp_kafka_error_total",
+		Help: `Total errors in the Kafka processor of any kind. This counter is
+		incremented liberally and may double-count an error that is returned up
+		the stack.`,
+	})
+)
+
 // StartConsumers reads configuration variables and starts the associated kafka consumers
 func StartConsumers(ctx context.Context, providedServer *server.Server, logger *zerolog.Logger) error {
 	adsRequestRedeemV1Topic := os.Getenv("REDEEM_CONSUMER_TOPIC")
@@ -53,12 +96,22 @@ func StartConsumers(ctx context.Context, providedServer *server.Server, logger *
 	adsResultSignV1Topic := os.Getenv("SIGN_PRODUCER_TOPIC")
 	adsConsumerGroupV1 := os.Getenv("CONSUMER_GROUP")
 
+	prometheus.MustRegister(tokenIssuanceRequestTotal)
+	prometheus.MustRegister(tokenIssuanceFailureTotal)
+	prometheus.MustRegister(tokenRedeemRequestTotal)
+	prometheus.MustRegister(tokenRedeemFailureTotal)
+	prometheus.MustRegister(duplicateRedemptionTotal)
+	prometheus.MustRegister(idempotentRedemptionTotal)
+	prometheus.MustRegister(rebootFromPanicTotal)
+	prometheus.MustRegister(kafkaErrorTotal)
+
 	if len(brokers) < 1 {
 		brokers = strings.Split(os.Getenv("VPC_KAFKA_BROKERS"), ",")
 	}
 
 	redeemDialer, err := getDialer(ctx, logger)
 	if err != nil {
+		kafkaErrorTotal.Inc()
 		return fmt.Errorf("failed to get redeem dialer: %w", err)
 	}
 	redeemWriter := kafkaGo.NewWriter(kafkaGo.WriterConfig{
@@ -69,6 +122,7 @@ func StartConsumers(ctx context.Context, providedServer *server.Server, logger *
 
 	signDialer, err := getDialer(ctx, logger)
 	if err != nil {
+		kafkaErrorTotal.Inc()
 		return fmt.Errorf("failed to get sign dialer: %w", err)
 	}
 	signWriter := kafkaGo.NewWriter(kafkaGo.WriterConfig{
@@ -81,14 +135,24 @@ func StartConsumers(ctx context.Context, providedServer *server.Server, logger *
 			Topic: adsRequestRedeemV1Topic,
 			Processor: func(ctx context.Context, msg kafkaGo.Message,
 				logger *zerolog.Logger) error {
-				return SignedTokenRedeemHandler(ctx, msg, redeemWriter, providedServer, logger)
+				tokenRedeemRequestTotal.Inc()
+				err := SignedTokenRedeemHandler(ctx, msg, redeemWriter, providedServer, logger)
+				if err != nil {
+					tokenRedeemFailureTotal.Inc()
+				}
+				return err
 			},
 		},
 		{
 			Topic: adsRequestSignV1Topic,
 			Processor: func(ctx context.Context, msg kafkaGo.Message,
 				logger *zerolog.Logger) error {
-				return SignedBlindedTokenIssuerHandler(ctx, msg, signWriter, providedServer, logger)
+				tokenIssuanceRequestTotal.Inc()
+				err := SignedBlindedTokenIssuerHandler(ctx, msg, signWriter, providedServer, logger)
+				if err != nil {
+					tokenIssuanceFailureTotal.Inc()
+				}
+				return err
 			},
 		},
 	}
@@ -99,6 +163,7 @@ func StartConsumers(ctx context.Context, providedServer *server.Server, logger *
 
 	reader, err := newConsumer(ctx, topics, adsConsumerGroupV1, logger)
 	if err != nil {
+		kafkaErrorTotal.Inc()
 		return fmt.Errorf("failed to get shared consumer dialer: %w", err)
 	}
 
@@ -109,6 +174,7 @@ func StartConsumers(ctx context.Context, providedServer *server.Server, logger *
 		if err != nil {
 			// If readAndCommitBatchPipelineResults returns an error.
 			close(batchPipeline)
+			kafkaErrorTotal.Inc()
 			return err
 		}
 	}
@@ -130,11 +196,13 @@ func readAndCommitBatchPipelineResults(
 
 	if msgCtx.err != nil {
 		logger.Error().Err(msgCtx.err).Msg("temporary failure encountered")
+		kafkaErrorTotal.Inc()
 		return fmt.Errorf("temporary failure encountered: %w", msgCtx.err)
 	}
-	logger.Info().Msgf("Committing offset %d", msgCtx.msg.Offset)
+	logger.Info().Msgf("committing offset %d", msgCtx.msg.Offset)
 	if err := reader.CommitMessages(ctx, msgCtx.msg); err != nil {
 		logger.Error().Err(err).Msg("failed to commit")
+		kafkaErrorTotal.Inc()
 		return errors.New("failed to commit")
 	}
 	return nil
@@ -150,6 +218,13 @@ func processMessagesIntoBatchPipeline(ctx context.Context,
 	batchPipeline chan *MessageContext,
 	logger *zerolog.Logger,
 ) {
+	// Catch the panic cases in order to count them, but continue to panic.
+	defer func() {
+		if r := recover(); r != nil {
+			rebootFromPanicTotal.Inc()
+			panic(r) // Re-panic to ensure termination
+		}
+	}()
 	// Loop forever
 	for {
 		msg, err := reader.FetchMessage(ctx)
@@ -157,9 +232,10 @@ func processMessagesIntoBatchPipeline(ctx context.Context,
 			// Indicates batch has no more messages. End the loop for
 			// this batch and fetch another.
 			if err == io.EOF {
-				logger.Info().Msg("Batch complete")
+				logger.Info().Msg("batch complete")
 			} else if errors.Is(err, context.DeadlineExceeded) {
 				logger.Error().Err(err).Msg("batch item error")
+				kafkaErrorTotal.Inc()
 				panic("failed to fetch kafka messages and closed channel")
 			}
 			// There are other possible errors, but the underlying consumer
@@ -176,8 +252,8 @@ func processMessagesIntoBatchPipeline(ctx context.Context,
 		// this write will panic, which is desired behavior, as the rest of the context
 		// will also have died and will be restarted from kafka/main.go
 		batchPipeline <- msgCtx
-		logger.Debug().Msgf("Processing message for topic %s at offset %d", msg.Topic, msg.Offset)
-		logger.Debug().Msgf("Reader Stats: %#v", reader.Stats())
+		logger.Debug().Msgf("processing message for topic %s at offset %d", msg.Topic, msg.Offset)
+		logger.Debug().Msgf("reader Stats: %#v", reader.Stats())
 		logger.Debug().Msgf("topicMappings: %+v", topicMappings)
 		go runMessageProcessor(ctx, msgCtx, topicMappings, logger)
 	}
@@ -206,14 +282,16 @@ func runMessageProcessor(
 	// This is a permanent error, so do not set msgCtx.err to commit the
 	// received message.
 	logger.Error().Msgf("topic received whose topic is not configured: %s", msg.Topic)
+	kafkaErrorTotal.Inc()
 }
 
 // NewConsumer returns a Kafka reader configured for the given topic and group.
 func newConsumer(ctx context.Context, topics []string, groupID string, logger *zerolog.Logger) (*kafkaGo.Reader, error) {
 	brokers = strings.Split(os.Getenv("VPC_KAFKA_BROKERS"), ",")
-	logger.Info().Msgf("Subscribing to kafka topic %s on behalf of group %s using brokers %s", topics, groupID, brokers)
+	logger.Info().Msgf("subscribing to kafka topic %s on behalf of group %s using brokers %s", topics, groupID, brokers)
 	dialer, err := getDialer(ctx, logger)
 	if err != nil {
+		kafkaErrorTotal.Inc()
 		return nil, err
 	}
 	reader := kafkaGo.NewReader(kafkaGo.ReaderConfig{
@@ -228,7 +306,7 @@ func newConsumer(ctx context.Context, topics []string, groupID string, logger *z
 		MinBytes:       1e3,              // 1KB
 		MaxBytes:       10e6,             // 10MB
 	})
-	logger.Trace().Msgf("Reader created with subscription")
+	logger.Trace().Msgf("reader created with subscription")
 	return reader, nil
 }
 
@@ -239,12 +317,13 @@ func Emit(
 	message []byte,
 	logger *zerolog.Logger,
 ) error {
-	logger.Info().Msgf("Beginning data emission for topic %s", producer.Topic)
+	logger.Info().Msgf("beginning data emission for topic %s", producer.Topic)
 
 	messageKey := uuid.New()
 	marshaledMessageKey, err := messageKey.MarshalBinary()
 	if err != nil {
 		logger.Error().Msgf("failed to marshal UUID into binary. Using default key value: %e", err)
+		kafkaErrorTotal.Inc()
 		marshaledMessageKey = []byte("default")
 	}
 
@@ -257,10 +336,11 @@ func Emit(
 	)
 	if err != nil {
 		logger.Error().Msgf("failed to write messages: %e", err)
+		kafkaErrorTotal.Inc()
 		return err
 	}
 
-	logger.Info().Msg("Data emitted")
+	logger.Info().Msg("data emitted")
 	return nil
 }
 
@@ -270,7 +350,7 @@ func getDialer(ctx context.Context, logger *zerolog.Logger) (*kafkaGo.Dialer, er
 	var dialer *kafkaGo.Dialer
 	env := os.Getenv("ENV")
 	if env != "local" {
-		logger.Info().Msg("Generating TLSDialer")
+		logger.Info().Msg("generating TLSDialer")
 		var cfg aws.Config
 		var err error
 
@@ -285,6 +365,7 @@ func getDialer(ctx context.Context, logger *zerolog.Logger) (*kafkaGo.Dialer, er
 
 		if err != nil {
 			logger.Error().Msgf("failed to setup aws config: %e", err)
+			kafkaErrorTotal.Inc()
 			return nil, err
 		}
 
@@ -295,10 +376,11 @@ func getDialer(ctx context.Context, logger *zerolog.Logger) (*kafkaGo.Dialer, er
 
 		if err != nil {
 			logger.Error().Msgf("failed to initialize TLS dialer: %e", err)
+			kafkaErrorTotal.Inc()
 			return nil, err
 		}
 	} else {
-		logger.Info().Msg("Generating Dialer")
+		logger.Info().Msg("generating Dialer")
 		dialer = &kafkaGo.Dialer{
 			Timeout:   10 * time.Second,
 			DualStack: true,

--- a/kafka/signed_token_redeem_handler.go
+++ b/kafka/signed_token_redeem_handler.go
@@ -45,6 +45,7 @@ func SignedTokenRedeemHandler(
 	tokenRedeemRequestSet, err := avroSchema.DeserializeRedeemRequestSet(bytes.NewReader(data))
 	if err != nil {
 		message := fmt.Sprintf("request %s: failed avro deserialization", tokenRedeemRequestSet.Request_id)
+		kafkaErrorTotal.Inc()
 		return handlePermanentRedemptionError(
 			ctx,
 			message,
@@ -66,6 +67,7 @@ func SignedTokenRedeemHandler(
 		// NOTE: When we start supporting multiple requests we will need to review
 		// errors and return values as well.
 		message := fmt.Sprintf("request %s: data array unexpectedly contained more than a single message. This array is intended to make future extension easier, but no more than a single value is currently expected", tokenRedeemRequestSet.Request_id)
+		kafkaErrorTotal.Inc()
 		return handlePermanentRedemptionError(
 			ctx,
 			message,
@@ -80,9 +82,11 @@ func SignedTokenRedeemHandler(
 	issuers, err := server.FetchAllIssuers()
 	if err != nil {
 		if processingError, ok := err.(*utils.ProcessingError); ok && processingError.Temporary {
+			kafkaErrorTotal.Inc()
 			return processingError
 		}
 		message := fmt.Sprintf("request %s: failed to fetch all issuers", tokenRedeemRequestSet.Request_id)
+		kafkaErrorTotal.Inc()
 		return handlePermanentRedemptionError(
 			ctx,
 			message,
@@ -116,6 +120,7 @@ func SignedTokenRedeemHandler(
 			// Unmarshalling failure is a data issue and is probably permanent.
 			if mErr != nil {
 				message := fmt.Sprintf("request %s: could not unmarshal issuer public key into text", tokenRedeemRequestSet.Request_id)
+				kafkaErrorTotal.Inc()
 				return handlePermanentRedemptionError(
 					ctx,
 					message,
@@ -147,6 +152,7 @@ func SignedTokenRedeemHandler(
 			logger.Error().
 				Err(fmt.Errorf("request %s: missing public key", tokenRedeemRequestSet.Request_id)).
 				Msg("signed token redeem handler")
+			kafkaErrorTotal.Inc()
 			redeemedTokenResults = append(redeemedTokenResults, avroSchema.RedeemResult{
 				Issuer_name:     "",
 				Issuer_cohort:   0,
@@ -161,6 +167,7 @@ func SignedTokenRedeemHandler(
 			logger.Error().
 				Err(fmt.Errorf("request %s: empty request", tokenRedeemRequestSet.Request_id)).
 				Msg("signed token redeem handler")
+			kafkaErrorTotal.Inc()
 			redeemedTokenResults = append(redeemedTokenResults, avroSchema.RedeemResult{
 				Issuer_name:     "",
 				Issuer_cohort:   0,
@@ -175,6 +182,7 @@ func SignedTokenRedeemHandler(
 		// Unmarshaling failure is a data issue and is probably permanent.
 		if err != nil {
 			message := fmt.Sprintf("request %s: could not unmarshal text into preimage", tokenRedeemRequestSet.Request_id)
+			kafkaErrorTotal.Inc()
 			return handlePermanentRedemptionError(
 				ctx,
 				message,
@@ -191,6 +199,7 @@ func SignedTokenRedeemHandler(
 		// Unmarshaling failure is a data issue and is probably permanent.
 		if err != nil {
 			message := fmt.Sprintf("request %s: could not unmarshal text into verification signature", tokenRedeemRequestSet.Request_id)
+			kafkaErrorTotal.Inc()
 			return handlePermanentRedemptionError(
 				ctx,
 				message,
@@ -228,6 +237,7 @@ func SignedTokenRedeemHandler(
 				Err(fmt.Errorf("request %s: could not verify that the token redemption is valid",
 					tokenRedeemRequestSet.Request_id)).
 				Msg("signed token redeem handler")
+			kafkaErrorTotal.Inc()
 			redeemedTokenResults = append(redeemedTokenResults, avroSchema.RedeemResult{
 				Issuer_name:     "",
 				Issuer_cohort:   0,
@@ -247,6 +257,7 @@ func SignedTokenRedeemHandler(
 				}
 			}
 			message := fmt.Sprintf("request %s: failed to check redemption equivalence", tokenRedeemRequestSet.Request_id)
+			kafkaErrorTotal.Inc()
 			return handlePermanentRedemptionError(
 				ctx,
 				message,
@@ -262,6 +273,7 @@ func SignedTokenRedeemHandler(
 		// Continue if there is a duplicate
 		switch equivalence {
 		case cbpServer.IDEquivalence:
+			duplicateRedemptionTotal.Inc()
 			redeemedTokenResults = append(redeemedTokenResults, avroSchema.RedeemResult{
 				Issuer_name:     verifiedIssuer.IssuerType,
 				Issuer_cohort:   int32(verifiedIssuer.IssuerCohort),
@@ -270,6 +282,7 @@ func SignedTokenRedeemHandler(
 			})
 			continue
 		case cbpServer.BindingEquivalence:
+			idempotentRedemptionTotal.Inc()
 			redeemedTokenResults = append(redeemedTokenResults, avroSchema.RedeemResult{
 				Issuer_name:     verifiedIssuer.IssuerType,
 				Issuer_cohort:   int32(verifiedIssuer.IssuerCohort),
@@ -282,6 +295,7 @@ func SignedTokenRedeemHandler(
 		// If no equivalent record was found in the database, persist.
 		if err := server.PersistRedemption(*redemption); err != nil {
 			logger.Error().Err(err).Msgf("request %s: token redemption failed: %e", tokenRedeemRequestSet.Request_id, err)
+			kafkaErrorTotal.Inc()
 			// In the unlikely event that there is a race condition that results
 			// in a duplicate error upon save that was not detected previously
 			// we will check equivalence upon receipt of a duplicate error.
@@ -357,6 +371,7 @@ func SignedTokenRedeemHandler(
 	err = resultSet.Serialize(&resultSetBuffer)
 	if err != nil {
 		message := fmt.Sprintf("request %s: failed to serialize result set", tokenRedeemRequestSet.Request_id)
+		kafkaErrorTotal.Inc()
 		return handlePermanentRedemptionError(
 			ctx,
 			message,
@@ -376,6 +391,7 @@ func SignedTokenRedeemHandler(
 			resultSet.Request_id,
 			producer.Topic,
 		)
+		kafkaErrorTotal.Inc()
 		return err
 	}
 
@@ -420,6 +436,7 @@ func avroRedeemErrorResultFromError(
 	err := resultSet.Serialize(&resultSetBuffer)
 	if err != nil {
 		message := fmt.Sprintf("request %s: failed to serialize result set", requestID)
+		kafkaErrorTotal.Inc()
 		return []byte(message)
 	}
 	return resultSetBuffer.Bytes()
@@ -438,6 +455,7 @@ func handlePermanentRedemptionError(
 	logger *zerolog.Logger,
 ) error {
 	logger.Error().Err(cause).Msgf("encountered permanent redemption failure: %v", message)
+	kafkaErrorTotal.Inc()
 	toEmit := avroRedeemErrorResultFromError(
 		message,
 		msg,
@@ -446,6 +464,7 @@ func handlePermanentRedemptionError(
 		logger,
 	)
 	if err := Emit(ctx, producer, toEmit, logger); err != nil {
+		kafkaErrorTotal.Inc()
 		logger.Error().Err(err).Msg("failed to emit")
 	}
 	// TODO: consider returning err here as failing to emit error should not

--- a/main.go
+++ b/main.go
@@ -92,15 +92,13 @@ func main() {
 	}
 
 	zeroLogger.Trace().Msg("Initializing API server")
-	go func() {
-		err = srv.ListenAndServe(serverCtx, logger)
-		if err != nil {
-			zeroLogger.Error().Err(err).Msg("Failed to initialize API server")
-			raven.CaptureErrorAndWait(err, nil)
-			logger.Panic(err)
-			return
-		}
-	}()
+	err = srv.ListenAndServe(serverCtx, logger)
+	if err != nil {
+		zeroLogger.Error().Err(err).Msg("Failed to initialize API server")
+		raven.CaptureErrorAndWait(err, nil)
+		logger.Panic(err)
+		return
+	}
 }
 
 func startKafka(srv server.Server, zeroLogger *zerolog.Logger) {

--- a/server/issuers.go
+++ b/server/issuers.go
@@ -123,6 +123,7 @@ func (c *Server) getIssuers(ctx context.Context, issuerType string) ([]model.Iss
 }
 
 func (c *Server) issuerGetHandlerV1(w http.ResponseWriter, r *http.Request) *handlers.AppError {
+	v1IssuerCallTotal.WithLabelValues("getIssuer").Inc()
 	defer closers.Panic(r.Context(), r.Body)
 
 	if issuerType := chi.URLParam(r, "type"); issuerType != "" {
@@ -142,6 +143,7 @@ func (c *Server) issuerGetHandlerV1(w http.ResponseWriter, r *http.Request) *han
 }
 
 func (c *Server) issuerHandlerV3(w http.ResponseWriter, r *http.Request) *handlers.AppError {
+	v3IssuerCallTotal.WithLabelValues("getIssuer").Inc()
 	issuerType := chi.URLParam(r, "type")
 
 	if issuerType == "" {
@@ -166,6 +168,7 @@ func (c *Server) issuerHandlerV3(w http.ResponseWriter, r *http.Request) *handle
 }
 
 func (c *Server) issuerHandlerV2(w http.ResponseWriter, r *http.Request) *handlers.AppError {
+	v2IssuerCallTotal.WithLabelValues("getIssuer").Inc()
 	defer closers.Panic(r.Context(), r.Body)
 
 	decoder := json.NewDecoder(http.MaxBytesReader(w, r.Body, maxRequestSize))
@@ -193,6 +196,7 @@ func (c *Server) issuerHandlerV2(w http.ResponseWriter, r *http.Request) *handle
 }
 
 func (c *Server) issuerGetAllHandler(w http.ResponseWriter, r *http.Request) *handlers.AppError {
+	v1IssuerCallTotal.WithLabelValues("getAllIssuers").Inc()
 	defer closers.Panic(r.Context(), r.Body)
 
 	issuers, appErr := c.FetchAllIssuers()
@@ -219,6 +223,7 @@ func (c *Server) issuerGetAllHandler(w http.ResponseWriter, r *http.Request) *ha
 
 // issuerV3CreateHandler - creation of a time aware issuer
 func (c *Server) issuerV3CreateHandler(w http.ResponseWriter, r *http.Request) *handlers.AppError {
+	v3IssuerCallTotal.WithLabelValues("createIssuer").Inc()
 	decoder := json.NewDecoder(http.MaxBytesReader(w, r.Body, maxRequestSize))
 	var req issuerV3CreateRequest
 	if err := decoder.Decode(&req); err != nil {
@@ -273,6 +278,7 @@ func (c *Server) issuerV3CreateHandler(w http.ResponseWriter, r *http.Request) *
 }
 
 func (c *Server) issuerCreateHandlerV2(w http.ResponseWriter, r *http.Request) *handlers.AppError {
+	v2IssuerCallTotal.WithLabelValues("createIssuer").Inc()
 	log := lg.Log(r.Context())
 
 	decoder := json.NewDecoder(http.MaxBytesReader(w, r.Body, maxRequestSize))
@@ -329,6 +335,7 @@ func (c *Server) issuerCreateHandlerV2(w http.ResponseWriter, r *http.Request) *
 }
 
 func (c *Server) issuerCreateHandlerV1(w http.ResponseWriter, r *http.Request) *handlers.AppError {
+	v1IssuerCallTotal.WithLabelValues("createIssuer").Inc()
 	log := lg.Log(r.Context())
 
 	decoder := json.NewDecoder(http.MaxBytesReader(w, r.Body, maxRequestSize))

--- a/server/tokens.go
+++ b/server/tokens.go
@@ -71,6 +71,7 @@ type BlindedTokenBulkRedeemRequest struct {
 
 // BlindedTokenIssuerHandlerV2 - handler for token issuer v2
 func (c *Server) BlindedTokenIssuerHandlerV2(w http.ResponseWriter, r *http.Request) *handlers.AppError {
+	v2BlindedTokenCallTotal.WithLabelValues("issueTokens").Inc()
 	var response blindedTokenIssueResponse
 	if issuerType := chi.URLParam(r, "type"); issuerType != "" {
 		var request BlindedTokenIssueRequestV2
@@ -129,6 +130,7 @@ func (c *Server) BlindedTokenIssuerHandlerV2(w http.ResponseWriter, r *http.Requ
 
 // Old endpoint, that always handles tokens with v1cohort
 func (c *Server) blindedTokenIssuerHandler(w http.ResponseWriter, r *http.Request) *handlers.AppError {
+	v1BlindedTokenCallTotal.WithLabelValues("issueToken").Inc()
 	var response blindedTokenIssueResponse
 	if issuerType := chi.URLParam(r, "type"); issuerType != "" {
 		issuer, appErr := c.GetLatestIssuer(issuerType, v1Cohort)
@@ -179,6 +181,7 @@ func (c *Server) blindedTokenIssuerHandler(w http.ResponseWriter, r *http.Reques
 }
 
 func (c *Server) blindedTokenRedeemHandlerV3(w http.ResponseWriter, r *http.Request) *handlers.AppError {
+	v3BlindedTokenCallTotal.WithLabelValues("redeemTokens").Inc()
 	ctx := r.Context()
 
 	issuerType := chi.URLParamFromCtx(ctx, "type")
@@ -295,6 +298,7 @@ func (c *Server) blindedTokenRedeemHandlerV3(w http.ResponseWriter, r *http.Requ
 }
 
 func (c *Server) blindedTokenRedeemHandler(w http.ResponseWriter, r *http.Request) *handlers.AppError {
+	v1BlindedTokenCallTotal.WithLabelValues("redeemToken").Inc()
 	var response blindedTokenRedeemResponse
 	if issuerType := chi.URLParam(r, "type"); issuerType != "" {
 		issuers, appErr := c.getIssuers(r.Context(), issuerType)
@@ -379,6 +383,7 @@ func (c *Server) blindedTokenRedeemHandler(w http.ResponseWriter, r *http.Reques
 }
 
 func (c *Server) blindedTokenBulkRedeemHandler(w http.ResponseWriter, r *http.Request) *handlers.AppError {
+	v1BlindedTokenCallTotal.WithLabelValues("bulkRedeemTokens").Inc()
 	var request BlindedTokenBulkRedeemRequest
 
 	if err := json.NewDecoder(http.MaxBytesReader(w, r.Body, maxRequestSize)).Decode(&request); err != nil {
@@ -461,6 +466,7 @@ func (c *Server) blindedTokenBulkRedeemHandler(w http.ResponseWriter, r *http.Re
 }
 
 func (c *Server) blindedTokenRedemptionHandler(w http.ResponseWriter, r *http.Request) *handlers.AppError {
+	v1BlindedTokenCallTotal.WithLabelValues("checkToken").Inc()
 	var response interface{}
 	if issuerID := chi.URLParam(r, "id"); issuerID != "" {
 		tokenID := chi.URLParam(r, "tokenId")


### PR DESCRIPTION
No changes to business logic.

1. Fix existing database metrics: Existing metrics are exposed on port `2416`. However, prometheus expects them on `9090`. This PR puts metrics on `9090`.
2. Retain existing metrics: The version of metrics on `2416` is retained, as it's the health check endpoint for the service. In the future, we should either expose a health endpoint or change the check to use metrics on `9090`. Either way, this version is compatible.
3. Add Kafka metrics: Add new metrics for Kafka behavior
4. Add endpoint metrics: Add new metrics for endpoints. I expect that `v1` and `v2` can be removed. However, we should use these new metrics to verify that calls are sufficiently low before doing so.

This change is running in Grants dev without issue.