### PR TITLE
Further Simplify Logging

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,17 @@ WORKDIR /src
 COPY . .
 RUN go mod download
 COPY --from=rust_builder /src/target/x86_64-unknown-linux-musl/release/libchallenge_bypass_ristretto_ffi.a /usr/lib/libchallenge_bypass_ristretto_ffi.a
-RUN go build -ldflags '-linkmode external -extldflags "-static"' -tags 'osusergo netgo static_build' -o challenge-bypass-server main.go
+
+ARG VERSION
+ARG COMMIT
+ARG BUILD_TIME
+RUN go build -ldflags "\
+    -X main.Version=${VERSION} \
+    -X main.BuildTime=${BUILD_TIME} \
+    -X main.Commit=${COMMIT} \
+    -linkmode external -extldflags \"-static\"" \
+    -tags "osusergo netgo static_build" \
+    -o challenge-bypass-server main.go
 CMD ["/src/challenge-bypass-server"]
 
 FROM ubuntu:22.04

--- a/go.mod
+++ b/go.mod
@@ -20,7 +20,6 @@ require (
 	github.com/patrickmn/go-cache v2.1.0+incompatible
 	github.com/prometheus/client_golang v1.14.0
 	github.com/robfig/cron/v3 v3.0.1
-	github.com/rs/zerolog v1.29.0
 	github.com/satori/go.uuid v1.2.0
 	github.com/segmentio/kafka-go v0.4.38
 	github.com/segmentio/kafka-go/sasl/aws_msk_iam_v2 v0.1.0
@@ -67,6 +66,7 @@ require (
 	github.com/prometheus/procfs v0.9.0 // indirect
 	github.com/redis/go-redis/v9 v9.8.0 // indirect
 	github.com/rs/xid v1.4.0 // indirect
+	github.com/rs/zerolog v1.29.0 // indirect
 	github.com/shengdoushi/base58 v1.0.0 // indirect
 	github.com/throttled/throttled/v2 v2.12.0 // indirect
 	go.uber.org/atomic v1.10.0 // indirect

--- a/kafka/main.go
+++ b/kafka/main.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"log/slog"
 	"os"
 	"strings"
 	"time"
@@ -16,7 +17,6 @@ import (
 	"github.com/brave-intl/challenge-bypass-server/server"
 	uuid "github.com/google/uuid"
 	"github.com/prometheus/client_golang/prometheus"
-	"github.com/rs/zerolog"
 	kafkaGo "github.com/segmentio/kafka-go"
 	"github.com/segmentio/kafka-go/sasl/aws_msk_iam_v2"
 )
@@ -24,7 +24,7 @@ import (
 var brokers []string
 
 // Processor is a function that is used to process Kafka messages on
-type Processor func(context.Context, kafkaGo.Message, *zerolog.Logger) error
+type Processor func(context.Context, kafkaGo.Message, *slog.Logger) error
 
 // Subset of kafka.Reader methods that we use. This is used for testing.
 type messageReader interface {
@@ -89,7 +89,7 @@ var (
 )
 
 // StartConsumers reads configuration variables and starts the associated kafka consumers
-func StartConsumers(ctx context.Context, providedServer *server.Server, logger *zerolog.Logger) error {
+func StartConsumers(ctx context.Context, providedServer *server.Server, logger *slog.Logger) error {
 	adsRequestRedeemV1Topic := os.Getenv("REDEEM_CONSUMER_TOPIC")
 	adsResultRedeemV1Topic := os.Getenv("REDEEM_PRODUCER_TOPIC")
 	adsRequestSignV1Topic := os.Getenv("SIGN_CONSUMER_TOPIC")
@@ -134,7 +134,7 @@ func StartConsumers(ctx context.Context, providedServer *server.Server, logger *
 		{
 			Topic: adsRequestRedeemV1Topic,
 			Processor: func(ctx context.Context, msg kafkaGo.Message,
-				logger *zerolog.Logger) error {
+				logger *slog.Logger) error {
 				tokenRedeemRequestTotal.Inc()
 				err := SignedTokenRedeemHandler(ctx, msg, redeemWriter, providedServer, logger)
 				if err != nil {
@@ -146,7 +146,7 @@ func StartConsumers(ctx context.Context, providedServer *server.Server, logger *
 		{
 			Topic: adsRequestSignV1Topic,
 			Processor: func(ctx context.Context, msg kafkaGo.Message,
-				logger *zerolog.Logger) error {
+				logger *slog.Logger) error {
 				tokenIssuanceRequestTotal.Inc()
 				err := SignedBlindedTokenIssuerHandler(ctx, msg, signWriter, providedServer, logger)
 				if err != nil {
@@ -172,6 +172,7 @@ func StartConsumers(ctx context.Context, providedServer *server.Server, logger *
 	for {
 		err := readAndCommitBatchPipelineResults(ctx, reader, batchPipeline, logger)
 		if err != nil {
+			logger.Error("failed to process batch pipeline", slog.Any("error", err))
 			// If readAndCommitBatchPipelineResults returns an error.
 			close(batchPipeline)
 			kafkaErrorTotal.Inc()
@@ -189,21 +190,19 @@ func readAndCommitBatchPipelineResults(
 	ctx context.Context,
 	reader *kafkaGo.Reader,
 	batchPipeline chan *MessageContext,
-	logger *zerolog.Logger,
+	logger *slog.Logger,
 ) error {
 	msgCtx := <-batchPipeline
 	<-msgCtx.done
 
 	if msgCtx.err != nil {
-		logger.Error().Err(msgCtx.err).Msg("temporary failure encountered")
 		kafkaErrorTotal.Inc()
 		return fmt.Errorf("temporary failure encountered: %w", msgCtx.err)
 	}
-	logger.Info().Msgf("committing offset %d", msgCtx.msg.Offset)
+	logger.Debug("committing offset", "offset", msgCtx.msg.Offset)
 	if err := reader.CommitMessages(ctx, msgCtx.msg); err != nil {
-		logger.Error().Err(err).Msg("failed to commit")
 		kafkaErrorTotal.Inc()
-		return errors.New("failed to commit")
+		return fmt.Errorf("failed to commit: %w", err)
 	}
 	return nil
 }
@@ -216,7 +215,7 @@ func processMessagesIntoBatchPipeline(ctx context.Context,
 	topicMappings []TopicMapping,
 	reader messageReader,
 	batchPipeline chan *MessageContext,
-	logger *zerolog.Logger,
+	logger *slog.Logger,
 ) {
 	// Catch the panic cases in order to count them, but continue to panic.
 	defer func() {
@@ -232,9 +231,8 @@ func processMessagesIntoBatchPipeline(ctx context.Context,
 			// Indicates batch has no more messages. End the loop for
 			// this batch and fetch another.
 			if err == io.EOF {
-				logger.Info().Msg("batch complete")
+				logger.Debug("batch complete")
 			} else if errors.Is(err, context.DeadlineExceeded) {
-				logger.Error().Err(err).Msg("batch item error")
 				kafkaErrorTotal.Inc()
 				panic("failed to fetch kafka messages and closed channel")
 			}
@@ -252,9 +250,9 @@ func processMessagesIntoBatchPipeline(ctx context.Context,
 		// this write will panic, which is desired behavior, as the rest of the context
 		// will also have died and will be restarted from kafka/main.go
 		batchPipeline <- msgCtx
-		logger.Debug().Msgf("processing message for topic %s at offset %d", msg.Topic, msg.Offset)
-		logger.Debug().Msgf("reader Stats: %#v", reader.Stats())
-		logger.Debug().Msgf("topicMappings: %+v", topicMappings)
+		logger.Debug("processing message", "topic", msg.Topic, "offset", msg.Offset)
+		logger.Debug("reader Stats", slog.Any("stats", reader.Stats()))
+		logger.Debug("topic mappings", slog.Any("topicMappings", topicMappings))
 		go runMessageProcessor(ctx, msgCtx, topicMappings, logger)
 	}
 }
@@ -268,12 +266,12 @@ func runMessageProcessor(
 	ctx context.Context,
 	msgCtx *MessageContext,
 	topicMappings []TopicMapping,
-	logger *zerolog.Logger,
+	logger *slog.Logger,
 ) {
 	defer close(msgCtx.done)
 	msg := msgCtx.msg
 	for _, topicMapping := range topicMappings {
-		logger.Debug().Msgf("topic: %+v, topicMapping: %+v", msg.Topic, topicMapping.Topic)
+		logger.Debug("iterating topic mapping", "topic", msg.Topic, "topicMapping", topicMapping.Topic)
 		if msg.Topic == topicMapping.Topic {
 			msgCtx.err = topicMapping.Processor(ctx, msg, logger)
 			return
@@ -281,32 +279,39 @@ func runMessageProcessor(
 	}
 	// This is a permanent error, so do not set msgCtx.err to commit the
 	// received message.
-	logger.Error().Msgf("topic received whose topic is not configured: %s", msg.Topic)
+	logger.Error("topic received whose topic is not configured", slog.Any("topic", msg.Topic))
 	kafkaErrorTotal.Inc()
 }
 
 // NewConsumer returns a Kafka reader configured for the given topic and group.
-func newConsumer(ctx context.Context, topics []string, groupID string, logger *zerolog.Logger) (*kafkaGo.Reader, error) {
+func newConsumer(ctx context.Context, topics []string, groupID string, logger *slog.Logger) (*kafkaGo.Reader, error) {
 	brokers = strings.Split(os.Getenv("VPC_KAFKA_BROKERS"), ",")
-	logger.Info().Msgf("subscribing to kafka topic %s on behalf of group %s using brokers %s", topics, groupID, brokers)
+	logger.Info("subscribing",
+		"topics", topics,
+		"group", groupID,
+		"brokers", brokers,
+	)
 	dialer, err := getDialer(ctx, logger)
 	if err != nil {
 		kafkaErrorTotal.Inc()
 		return nil, err
 	}
+	// kafka-go's ReaderConfig requires the old styl log.Logger
+	// We can make one from our slog.Logger.
+	logLogger := slog.NewLogLogger(logger.Handler(), slog.LevelInfo)
 	reader := kafkaGo.NewReader(kafkaGo.ReaderConfig{
 		Brokers:        brokers,
 		Dialer:         dialer,
 		GroupTopics:    topics,
 		GroupID:        groupID,
 		StartOffset:    kafkaGo.FirstOffset,
-		Logger:         logger,
+		Logger:         logLogger,
 		MaxWait:        time.Second * 20, // default 20s
 		CommitInterval: time.Second,      // flush commits to Kafka every second
 		MinBytes:       1e3,              // 1KB
 		MaxBytes:       10e6,             // 10MB
 	})
-	logger.Trace().Msgf("reader created with subscription")
+	logger.Debug("reader created with subscription")
 	return reader, nil
 }
 
@@ -315,14 +320,17 @@ func Emit(
 	ctx context.Context,
 	producer *kafkaGo.Writer,
 	message []byte,
-	logger *zerolog.Logger,
+	logger *slog.Logger,
 ) error {
-	logger.Info().Msgf("beginning data emission for topic %s", producer.Topic)
+	logger.Info("beginning data emission", "topic", producer.Topic)
 
 	messageKey := uuid.New()
 	marshaledMessageKey, err := messageKey.MarshalBinary()
 	if err != nil {
-		logger.Error().Msgf("failed to marshal UUID into binary. Using default key value: %e", err)
+		logger.Error(
+			"failed to marshal UUID into binary using default key value",
+			slog.Any("error", err),
+		)
 		kafkaErrorTotal.Inc()
 		marshaledMessageKey = []byte("default")
 	}
@@ -335,22 +343,21 @@ func Emit(
 		},
 	)
 	if err != nil {
-		logger.Error().Msgf("failed to write messages: %e", err)
 		kafkaErrorTotal.Inc()
-		return err
+		return fmt.Errorf("failed to write messages: %w", err)
 	}
 
-	logger.Info().Msg("data emitted")
+	logger.Debug("data emitted")
 	return nil
 }
 
 // getDialer returns a reference to a Kafka dialer. The dialer is TLS enabled in non-local
 // environments.
-func getDialer(ctx context.Context, logger *zerolog.Logger) (*kafkaGo.Dialer, error) {
+func getDialer(ctx context.Context, logger *slog.Logger) (*kafkaGo.Dialer, error) {
 	var dialer *kafkaGo.Dialer
 	env := os.Getenv("ENV")
 	if env != "local" {
-		logger.Info().Msg("generating TLSDialer")
+		logger.Debug("generating TLSDialer")
 		var cfg aws.Config
 		var err error
 
@@ -364,9 +371,8 @@ func getDialer(ctx context.Context, logger *zerolog.Logger) (*kafkaGo.Dialer, er
 		}
 
 		if err != nil {
-			logger.Error().Msgf("failed to setup aws config: %e", err)
 			kafkaErrorTotal.Inc()
-			return nil, err
+			return nil, fmt.Errorf("failed to setup aws config: %w", err)
 		}
 
 		mechanism := aws_msk_iam_v2.NewMechanism(cfg)
@@ -375,12 +381,11 @@ func getDialer(ctx context.Context, logger *zerolog.Logger) (*kafkaGo.Dialer, er
 		dialer.SASLMechanism = mechanism
 
 		if err != nil {
-			logger.Error().Msgf("failed to initialize TLS dialer: %e", err)
 			kafkaErrorTotal.Inc()
-			return nil, err
+			return nil, fmt.Errorf("failed to initialize TLS dialer: %w", err)
 		}
 	} else {
-		logger.Info().Msg("generating Dialer")
+		logger.Debug("generating Dialer")
 		dialer = &kafkaGo.Dialer{
 			Timeout:   10 * time.Second,
 			DualStack: true,

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -27,6 +27,13 @@ import (
 	"github.com/stretchr/testify/suite"
 )
 
+// Build information - populated at build time
+var (
+	Version   = "dev"
+	BuildTime = "unknown"
+	Commit    = "none"
+)
+
 type ServerTestSuite struct {
 	suite.Suite
 	handler     http.Handler
@@ -53,12 +60,24 @@ func (suite *ServerTestSuite) SetupSuite() {
 	suite.srv.InitDB()
 	suite.srv.InitDynamo()
 
-	_, suite.handler = suite.srv.setupRouter(SetupLogger(context.Background()))
+	_, suite.handler = suite.srv.setupRouter(
+		SetupLogger(
+			context.Background(),
+			Version,
+			BuildTime,
+			Commit,
+		))
 
 	err = test.SetupDynamodbTables(suite.srv.dynamo)
 	suite.Require().NoError(err)
 
-	_, suite.handler = suite.srv.setupRouter(SetupLogger(context.Background()))
+	_, suite.handler = suite.srv.setupRouter(
+		SetupLogger(
+			context.Background(),
+			Version,
+			BuildTime,
+			Commit,
+		))
 }
 
 func (suite *ServerTestSuite) SetupTest() {


### PR DESCRIPTION
Last week, we removed the `logrus` dependency in the API. This PR removes the `zerolog` dependency from Kafka and unifies all logging under the standard library's `slog`. Minor improvements to log details are included, as well as a fix for the missing duplicate redemption metrics discovered after the last release.

Contrary to some older commit messages, this version does not fork Kafka and the API.