### PR TITLE
Distinguish database reader and writer instances

### DIFF
--- a/main.go
+++ b/main.go
@@ -59,7 +59,7 @@ func main() {
 	logger.Debug("Initializing persistence and cron jobs")
 
 	// Initialize databases and cron tasks before the Kafka processors and server start
-	srv.InitDB()
+	srv.InitDB(logger)
 	srv.InitDynamo()
 	// Run the cron job unless it's explicitly disabled.
 	if os.Getenv("CRON_ENABLED") != "false" {

--- a/server/db.go
+++ b/server/db.go
@@ -111,7 +111,7 @@ func (c *Server) InitDB(logger *slog.Logger) {
 		panic(err)
 	}
 	if cfg.ConnectionURIReader != "" {
-		dbr, err = makeDBConnection(cfg.ConnectionURI, cfg.MaxConnection)
+		dbr, err = makeDBConnection(cfg.ConnectionURIReader, cfg.MaxConnection)
 		if err != nil {
 			logger.Warn("database reader instance not connected")
 		}

--- a/server/db.go
+++ b/server/db.go
@@ -35,6 +35,7 @@ type CachingConfig struct {
 // DBConfig defines app configurations
 type DBConfig struct {
 	ConnectionURI           string        `json:"connectionURI"`
+	ConnectionURIReader     string        `json:"connectionURIReader"`
 	CachingConfig           CachingConfig `json:"caching"`
 	MaxConnection           int           `json:"maxConnection"`
 	DefaultDaysBeforeExpiry int           `json:"DefaultDaysBeforeExpiry"`
@@ -84,28 +85,52 @@ func (c *Server) LoadDBConfig(config DBConfig) {
 	c.dbConfig = config
 }
 
-// InitDB initialzes the database connection based on a server's configuration
-func (c *Server) InitDB() {
-	cfg := c.dbConfig
-	db, err := sql.Open("postgres", cfg.ConnectionURI)
+func makeDBConnection(uri string, maxConnection int) (*sql.DB, error) {
+	db, err := sql.Open("postgres", uri)
 	if err != nil {
-		panic(err)
+		return nil, err
 	}
 
-	// Connection pool settings
-	db.SetMaxOpenConns(cfg.MaxConnection)
-	db.SetMaxIdleConns(cfg.MaxConnection / 2)
+	db.SetMaxOpenConns(maxConnection)
+	db.SetMaxIdleConns(maxConnection / 2)
 	db.SetConnMaxLifetime(5 * time.Minute)
 	db.SetConnMaxIdleTime(90 * time.Second)
 
-	c.db = db
+	return db, nil
+}
+
+// InitDB initialzes the database connection based on a server's configuration
+func (c *Server) InitDB(logger *slog.Logger) {
+	var (
+		dbw *sql.DB // Database writer connection
+		dbr *sql.DB // Database reader connection
+	)
+	cfg := c.dbConfig
+	dbw, err := makeDBConnection(cfg.ConnectionURI, cfg.MaxConnection)
+	if err != nil {
+		panic(err)
+	}
+	if cfg.ConnectionURIReader != "" {
+		dbr, err = makeDBConnection(cfg.ConnectionURI, cfg.MaxConnection)
+		if err != nil {
+			logger.Warn("database reader instance not connected")
+		}
+	}
+
+	c.db = dbw
+	// Use the writer for the reader as well if the reader connection is missing
+	if dbr != nil {
+		c.dbr = dbr
+	} else {
+		c.dbr = dbw
+	}
 
 	// Database Telemetry
-	collector := metrics.NewStatsCollector("challenge_bypass_db", db)
+	collector := metrics.NewStatsCollector("challenge_bypass_db", dbw)
 	err = prometheus.Register(collector)
 	if ae, ok := err.(prometheus.AlreadyRegisteredError); ok {
 		if sc, ok := ae.ExistingCollector.(*metrics.StatsCollector); ok {
-			sc.AddStatsGetter("challenge_bypass_db", db)
+			sc.AddStatsGetter("challenge_bypass_db", dbw)
 		}
 	}
 
@@ -113,7 +138,7 @@ func (c *Server) InitDB() {
 		time.Sleep(10 * time.Second)
 	}
 
-	driver, err := postgres.WithInstance(db, &postgres.Config{})
+	driver, err := postgres.WithInstance(dbw, &postgres.Config{})
 	if err != nil {
 		panic(err)
 	}
@@ -203,7 +228,7 @@ func (c *Server) fetchIssuer(issuerID string) (*model.Issuer, error) {
 
 	query := fmt.Sprintf(`SELECT %s FROM v3_issuers WHERE issuer_id=$1`, issuerColumns)
 
-	row := c.db.QueryRow(query, issuerID)
+	row := c.dbr.QueryRow(query, issuerID)
 
 	var fetchedIssuer model.Issuer
 	err := scanIssuer(row, &fetchedIssuer)
@@ -334,7 +359,7 @@ func (c *Server) fetchIssuersByCohort(
 		}
 	}
 
-	rows, err := c.db.Query(queryTemplate, issuerType, issuerCohort)
+	rows, err := c.dbr.Query(queryTemplate, issuerType, issuerCohort)
 	if err != nil {
 		c.Logger.Error("Failed to extract issuers from DB")
 		return nil, utils.ProcessingErrorFromError(err, true)
@@ -383,7 +408,7 @@ func (c *Server) fetchIssuerByType(ctx context.Context, issuerType string) (*mod
               ORDER BY expires_at DESC NULLS LAST, created_at DESC
               LIMIT 1`, issuerColumns)
 
-	row := c.db.QueryRowContext(ctx, query, issuerType)
+	row := c.dbr.QueryRowContext(ctx, query, issuerType)
 
 	var issuerV3 model.Issuer
 	err := scanIssuer(row, &issuerV3)
@@ -416,7 +441,7 @@ func (c *Server) FetchAllIssuers() ([]model.Issuer, error) {
 	query := fmt.Sprintf(`SELECT %s FROM v3_issuers 
               ORDER BY expires_at DESC NULLS LAST, created_at DESC`, issuerColumns)
 
-	rows, err := c.db.Query(query)
+	rows, err := c.dbr.Query(query)
 	if err != nil {
 		c.Logger.Error("Failed to extract issuers from DB")
 		return nil, utils.ProcessingErrorFromError(err, true)
@@ -467,7 +492,7 @@ func (c *Server) fetchIssuerKeysForIssuer(issuerID string) ([]model.IssuerKeys, 
                 AND (start_at <= now() OR start_at IS NULL)
               ORDER BY end_at ASC NULLS LAST, start_at ASC, created_at ASC`
 
-	rows, err := c.db.Query(query, issuerID)
+	rows, err := c.dbr.Query(query, issuerID)
 	if err != nil {
 		return nil, err
 	}
@@ -527,7 +552,7 @@ func (c *Server) fetchIssuerKeys(fetchedIssuers []model.Issuer) ([]model.Issuer,
                     AND ($2 OR end_at > now())
                   ORDER BY end_at ASC NULLS FIRST, start_at ASC`
 
-		rows, err := c.db.Query(query, issuerIDStr, lteVersionTwo)
+		rows, err := c.dbr.Query(query, issuerIDStr, lteVersionTwo)
 		if err != nil {
 			isNotPostgresNotFoundError := !isPostgresNotFoundError(err)
 			if isNotPostgresNotFoundError {
@@ -1097,7 +1122,7 @@ func (c *Server) fetchRedemption(issuerType, id string) (*Redemption, error) {
 	}
 
 	queryTimer := prometheus.NewTimer(fetchRedemptionDBDuration)
-	rows, err := c.db.Query(
+	rows, err := c.dbr.Query(
 		`SELECT id, issuer_id, ts, payload FROM redemptions WHERE id = $1 AND issuer_type = $2`, id, issuerType)
 	queryTimer.ObserveDuration()
 

--- a/server/server.go
+++ b/server/server.go
@@ -146,6 +146,10 @@ func (c *Server) InitDBConfig() error {
 		conf.ConnectionURI = os.Getenv("DATABASE_URL")
 	}
 
+	if connectionURIReader := os.Getenv("DATABASE_READER_URL"); connectionURIReader != "" {
+		conf.ConnectionURIReader = os.Getenv("DATABASE_READER_URL")
+	}
+
 	if dynamodbEndpoint := os.Getenv("DYNAMODB_ENDPOINT"); dynamodbEndpoint != "" {
 		conf.DynamodbEndpoint = os.Getenv("DYNAMODB_ENDPOINT")
 	}

--- a/server/server.go
+++ b/server/server.go
@@ -108,7 +108,8 @@ type Server struct {
 	Logger       *slog.Logger `json:",omitempty"`
 	dynamo       *dynamodb.DynamoDB
 	dbConfig     DBConfig
-	db           *sql.DB
+	db           *sql.DB // Database writer instance
+	dbr          *sql.DB // Database reader instance
 
 	caches map[string]CacheInterface
 }

--- a/server/server.go
+++ b/server/server.go
@@ -141,18 +141,9 @@ func (c *Server) InitDBConfig() error {
 		MaxConnection:           100,
 	}
 
-	// Heroku style
-	if connectionURI := os.Getenv("DATABASE_URL"); connectionURI != "" {
-		conf.ConnectionURI = os.Getenv("DATABASE_URL")
-	}
-
-	if connectionURIReader := os.Getenv("DATABASE_READER_URL"); connectionURIReader != "" {
-		conf.ConnectionURIReader = os.Getenv("DATABASE_READER_URL")
-	}
-
-	if dynamodbEndpoint := os.Getenv("DYNAMODB_ENDPOINT"); dynamodbEndpoint != "" {
-		conf.DynamodbEndpoint = os.Getenv("DYNAMODB_ENDPOINT")
-	}
+	conf.ConnectionURI = os.Getenv("DATABASE_URL")
+	conf.ConnectionURIReader = os.Getenv("DATABASE_READER_URL")
+	conf.DynamodbEndpoint = os.Getenv("DYNAMODB_ENDPOINT")
 
 	if maxConnection := os.Getenv("MAX_DB_CONNECTION"); maxConnection != "" {
 		if count, err := strconv.Atoi(maxConnection); err == nil {

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"log/slog"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -59,7 +60,7 @@ func (suite *ServerTestSuite) SetupSuite() {
 	err = suite.srv.InitDBConfig()
 	suite.Require().NoError(err, "Failed to setup db conn")
 
-	suite.srv.InitDB()
+	suite.srv.InitDB(slog.New(slog.DiscardHandler))
 	suite.srv.InitDynamo()
 
 	_, suite.handler = suite.srv.setupRouter(


### PR DESCRIPTION
Today, the service only interacts with the database writer instance. This PR allows optional configuration to use a reader instance for read-only operations by providing the `DATABASE_READER_URL` configuration value.