### PR TITLE
 Make Kafka consumer MinBytes configurable via environment variable

### DIFF
--- a/kafka/main.go
+++ b/kafka/main.go
@@ -328,7 +328,7 @@ func newConsumer(ctx context.Context, topics []string, groupID string, logger *s
 	// kafka-go's ReaderConfig requires the old style log.Logger
 	// We can make one from our slog.Logger.
 	logLogger := slog.NewLogLogger(logger.Handler(), slog.LevelInfo)
-	minBytes := int(1e3) // 1KB default
+	minBytes := int(1)
 	if v := os.Getenv("KAFKA_CONSUMER_MIN_BYTES"); v != "" {
 		if parsed, err := strconv.Atoi(v); err == nil {
 			minBytes = parsed

--- a/kafka/main.go
+++ b/kafka/main.go
@@ -156,7 +156,8 @@ func StartConsumers(
 		{
 			Topic: adsRequestRedeemV1Topic,
 			Processor: func(ctx context.Context, msg kafkaGo.Message,
-				logger *slog.Logger) error {
+				logger *slog.Logger,
+			) error {
 				tokenRedeemRequestTotal.Inc()
 				err := SignedTokenRedeemHandler(ctx, msg, redeemWriter, providedServer, logger)
 				if err != nil {
@@ -168,7 +169,8 @@ func StartConsumers(
 		{
 			Topic: adsRequestSignV1Topic,
 			Processor: func(ctx context.Context, msg kafkaGo.Message,
-				logger *slog.Logger) error {
+				logger *slog.Logger,
+			) error {
 				tokenIssuanceRequestTotal.Inc()
 				err := SignedBlindedTokenIssuerHandler(ctx, msg, signWriter, providedServer, logger)
 				if err != nil {
@@ -322,7 +324,7 @@ func newConsumer(ctx context.Context, topics []string, groupID string, logger *s
 		kafkaErrorTotal.Inc()
 		return nil, err
 	}
-	// kafka-go's ReaderConfig requires the old styl log.Logger
+	// kafka-go's ReaderConfig requires the old style log.Logger
 	// We can make one from our slog.Logger.
 	logLogger := slog.NewLogLogger(logger.Handler(), slog.LevelInfo)
 	reader := kafkaGo.NewReader(kafkaGo.ReaderConfig{
@@ -334,8 +336,8 @@ func newConsumer(ctx context.Context, topics []string, groupID string, logger *s
 		Logger:         logLogger,
 		MaxWait:        time.Second * 20, // default 20s
 		CommitInterval: time.Second,      // flush commits to Kafka every second
-		MinBytes:       1e3,              // 1KB
 		MaxBytes:       10e6,             // 10MB
+		MinBytes:       1,
 	})
 	logger.Debug("reader created with subscription")
 	return reader, nil

--- a/kafka/main.go
+++ b/kafka/main.go
@@ -328,7 +328,7 @@ func newConsumer(ctx context.Context, topics []string, groupID string, logger *s
 	// kafka-go's ReaderConfig requires the old style log.Logger
 	// We can make one from our slog.Logger.
 	logLogger := slog.NewLogLogger(logger.Handler(), slog.LevelInfo)
-	minBytes := int(1)
+	minBytes := int(1e3) // 1KB default
 	if v := os.Getenv("KAFKA_CONSUMER_MIN_BYTES"); v != "" {
 		if parsed, err := strconv.Atoi(v); err == nil {
 			minBytes = parsed

--- a/kafka/main.go
+++ b/kafka/main.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"log/slog"
 	"os"
+	"strconv"
 	"strings"
 	"time"
 
@@ -327,6 +328,12 @@ func newConsumer(ctx context.Context, topics []string, groupID string, logger *s
 	// kafka-go's ReaderConfig requires the old style log.Logger
 	// We can make one from our slog.Logger.
 	logLogger := slog.NewLogLogger(logger.Handler(), slog.LevelInfo)
+	minBytes := int(1e3) // 1KB default
+	if v := os.Getenv("KAFKA_CONSUMER_MIN_BYTES"); v != "" {
+		if parsed, err := strconv.Atoi(v); err == nil {
+			minBytes = parsed
+		}
+	}
 	reader := kafkaGo.NewReader(kafkaGo.ReaderConfig{
 		Brokers:        brokers,
 		Dialer:         dialer,
@@ -337,7 +344,7 @@ func newConsumer(ctx context.Context, topics []string, groupID string, logger *s
 		MaxWait:        time.Second * 20, // default 20s
 		CommitInterval: time.Second,      // flush commits to Kafka every second
 		MaxBytes:       10e6,             // 10MB
-		MinBytes:       1,
+		MinBytes:       minBytes,
 	})
 	logger.Debug("reader created with subscription")
 	return reader, nil


### PR DESCRIPTION
Make Kafka consumer MinBytes configurable via environment variable

  Adds KAFKA_CONSUMER_MIN_BYTES env var to control the kafka-go ReaderConfig.MinBytes setting. Defaults to 1 (current testing value; set to 1000 for 1KB in production).
  Invalid or missing values fall back to the default silently.

  Also fixes a typo in a comment (styl → style) and minor formatting cleanup on closure signatures.
