### PR TITLE
chore: code-quality cleanup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ docker-test:
 	--key-schema AttributeName=id,KeyType=HASH \
 	--billing-mode PAY_PER_REQUEST \
 	--table-name redemptions --endpoint-url http://dynamodb:8000 --region us-west-2 ) \
-	&& go test -v -tags='!integration' ./..."
+	&& go test -v -tags=db ./..."
 
 docker-lint:
 	docker compose -f docker-compose.yml -f docker-compose.dev.yml run --rm -p 2416:2416 challenge-bypass golangci-lint run

--- a/kafka/signed_token_redeem_handler.go
+++ b/kafka/signed_token_redeem_handler.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
-	"strings"
 	"time"
 
 	"github.com/segmentio/kafka-go"
@@ -305,7 +304,7 @@ func SignedTokenRedeemHandler(
 			// In the unlikely event that there is a race condition that results
 			// in a duplicate error upon save that was not detected previously
 			// we will check equivalence upon receipt of a duplicate error.
-			if strings.Contains(strings.ToLower(err.Error()), "duplicate") {
+			if errors.Is(err, cbpServer.ErrDuplicateRedemption) {
 				_, equivalence, err := server.CheckRedeemedTokenEquivalence(verifiedIssuer, &tokenPreimage, request.Binding, msg.Offset)
 				if err != nil {
 					message := fmt.Sprintf("request %s: failed to check redemption equivalence", tokenRedeemRequestSet.Request_id)

--- a/server/app_handler.go
+++ b/server/app_handler.go
@@ -3,7 +3,6 @@ package server
 import (
 	"encoding/json"
 	"fmt"
-	"log/slog"
 	"net/http"
 )
 
@@ -53,13 +52,8 @@ type AppHandler func(http.ResponseWriter, *http.Request) *AppError
 // ServeHTTP makes AppHandler satisfy the http.Handler interface
 func (fn AppHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	if err := fn(w, r); err != nil {
-		// Log the error
-		if logger, ok := r.Context().Value("logger").(*slog.Logger); ok && err.Cause != nil {
-			logger.Error("handler error",
-				slog.String("message", err.Message),
-				slog.Any("error", err.Cause))
-		}
-		// Render the error response
+		// Render the error response. Handlers log their own cause before
+		// returning, so there is no logging at this edge.
 		w.Header().Set("Content-Type", "application/json; charset=utf-8")
 		w.WriteHeader(err.Code)
 		// Create the error response

--- a/server/app_handler_test.go
+++ b/server/app_handler_test.go
@@ -1,0 +1,83 @@
+package server
+
+import (
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	should "github.com/stretchr/testify/assert"
+	must "github.com/stretchr/testify/require"
+)
+
+func TestAppError_Error(t *testing.T) {
+	should.Equal(t, "boom", (&AppError{Message: "boom"}).Error())
+	should.Equal(t, "boom: root cause",
+		(&AppError{Message: "boom", Cause: errors.New("root cause")}).Error())
+}
+
+func TestRenderContent(t *testing.T) {
+	t.Run("nil_renders_empty_object", func(t *testing.T) {
+		rec := httptest.NewRecorder()
+
+		err := RenderContent(nil, rec, http.StatusOK)
+
+		must.NoError(t, err)
+		should.Equal(t, http.StatusOK, rec.Code)
+		should.Equal(t, "application/json; charset=utf-8", rec.Header().Get("Content-Type"))
+		should.Equal(t, "{}", rec.Body.String())
+	})
+
+	t.Run("struct_is_json_encoded", func(t *testing.T) {
+		rec := httptest.NewRecorder()
+
+		err := RenderContent(map[string]string{"a": "b"}, rec, http.StatusCreated)
+
+		must.NoError(t, err)
+		should.Equal(t, http.StatusCreated, rec.Code)
+		should.JSONEq(t, `{"a":"b"}`, rec.Body.String())
+	})
+}
+
+func TestAppHandler_ServeHTTP(t *testing.T) {
+	t.Run("error_without_equivalence", func(t *testing.T) {
+		h := AppHandler(func(w http.ResponseWriter, r *http.Request) *AppError {
+			return &AppError{Message: "bad request", Code: http.StatusBadRequest}
+		})
+		rec := httptest.NewRecorder()
+
+		h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/", nil))
+
+		should.Equal(t, http.StatusBadRequest, rec.Code)
+		should.Equal(t, "application/json; charset=utf-8", rec.Header().Get("Content-Type"))
+		should.JSONEq(t, `{"message":"bad request"}`, rec.Body.String())
+	})
+
+	// Regression guard for the equivalence-serialization fix: a duplicate
+	// redemption must surface the equivalence field in the JSON envelope.
+	t.Run("error_with_equivalence_is_serialized", func(t *testing.T) {
+		h := AppHandler(func(w http.ResponseWriter, r *http.Request) *AppError {
+			return &AppError{Message: "duplicate", Code: http.StatusConflict, Equivalence: "id"}
+		})
+		rec := httptest.NewRecorder()
+
+		h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/", nil))
+
+		should.Equal(t, http.StatusConflict, rec.Code)
+		should.JSONEq(t, `{"message":"duplicate","equivalence":"id"}`, rec.Body.String())
+	})
+
+	t.Run("nil_error_leaves_handler_response_untouched", func(t *testing.T) {
+		h := AppHandler(func(w http.ResponseWriter, r *http.Request) *AppError {
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("ok"))
+			return nil
+		})
+		rec := httptest.NewRecorder()
+
+		h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/", nil))
+
+		should.Equal(t, http.StatusOK, rec.Code)
+		should.Equal(t, "ok", rec.Body.String())
+	})
+}

--- a/server/cache.go
+++ b/server/cache.go
@@ -12,12 +12,6 @@ type CachingConfig struct {
 	ExpirationSec int  `json:"expirationSec"`
 }
 
-type Cache[T any] interface {
-	Get(k string) (T, bool)
-	Delete(k string)
-	SetDefault(k string, x T)
-}
-
 // Clock interface allows us to mock time in tests
 type Clock interface {
 	Now() time.Time
@@ -125,10 +119,10 @@ func (c *SimpleCache[T]) SetDefault(k string, x T) {
 }
 
 type CacheCollection struct {
-	Issuer       Cache[*model.Issuer]
-	Issuers      Cache[[]model.Issuer]
-	Redemptions  Cache[*Redemption]
-	IssuerCohort Cache[[]model.Issuer]
+	Issuer       *SimpleCache[*model.Issuer]
+	Issuers      *SimpleCache[[]model.Issuer]
+	Redemptions  *SimpleCache[*Redemption]
+	IssuerCohort *SimpleCache[[]model.Issuer]
 }
 
 func bootstrapCache(cfg DBConfig) *CacheCollection {

--- a/server/cache_test.go
+++ b/server/cache_test.go
@@ -394,8 +394,7 @@ func TestBootstrapCache(t *testing.T) {
 			require.NotNil(t, caches.Redemptions, "Expected Redemptions cache")
 			require.NotNil(t, caches.IssuerCohort, "Expected IssuerCohort cache")
 
-			issuerCache, ok := caches.Issuer.(*SimpleCache[*model.Issuer])
-			require.True(t, ok, "Expected Issuer cache to be *SimpleCache")
+			issuerCache := caches.Issuer
 			assert.Equal(t, tt.wantExpiration, issuerCache.defaultExpiration,
 				"Expected defaultExpiration for Issuer cache")
 			assert.Equal(t, tt.wantCleanup, issuerCache.cleanupInterval,

--- a/server/db.go
+++ b/server/db.go
@@ -58,8 +58,10 @@ type RedemptionV2 struct {
 var (
 	errIssuerNotFound       = errors.New("issuer with the given name does not exist")
 	errIssuerCohortNotFound = errors.New("issuer with the given name and cohort does not exist")
-	errDuplicateRedemption  = errors.New("duplicate Redemption")
-	errRedemptionNotFound   = errors.New("redemption with the given id does not exist")
+	// ErrDuplicateRedemption is returned when a token has already been redeemed.
+	// Exported so callers in other packages (e.g. kafka) can match it with errors.Is.
+	ErrDuplicateRedemption = errors.New("duplicate redemption")
+	errRedemptionNotFound  = errors.New("redemption with the given id does not exist")
 )
 
 const issuerColumns = `issuer_id, issuer_type, created_at, expires_at, last_rotated_at,
@@ -1104,7 +1106,7 @@ func redeemTokenWithDB(db Queryable, stringIssuer string, preimage *crypto.Token
 		`INSERT INTO redemptions(id, issuer_type, ts, payload) VALUES ($1, $2, NOW(), $3)`, preimageTxt, stringIssuer, payload)
 	if err != nil {
 		if err, ok := err.(*pq.Error); ok && err.Code == "23505" { // unique constraint violation
-			return errDuplicateRedemption
+			return ErrDuplicateRedemption
 		}
 		return err
 	}

--- a/server/dynamo.go
+++ b/server/dynamo.go
@@ -168,7 +168,7 @@ func (c *Server) redeemTokenWithDynamo(issuer *model.Issuer, preimage *crypto.To
 	if err != nil {
 		if err, ok := err.(awserr.Error); ok && err.Code() == "ConditionalCheckFailedException" { // unique constraint violation
 			c.Logger.Error("Duplicate redemption")
-			return errDuplicateRedemption
+			return ErrDuplicateRedemption
 		}
 		c.Logger.Error("Error creating item")
 		return err
@@ -194,7 +194,7 @@ func (c *Server) PersistRedemption(redemption RedemptionV2) error {
 	if err != nil {
 		if err, ok := err.(awserr.Error); ok && err.Code() == "ConditionalCheckFailedException" { // unique constraint violation
 			c.Logger.Error("Duplicate redemption")
-			return errDuplicateRedemption
+			return ErrDuplicateRedemption
 		}
 		c.Logger.Error("Error creating item")
 		return err

--- a/server/middleware_test.go
+++ b/server/middleware_test.go
@@ -1,0 +1,114 @@
+package server
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	should "github.com/stretchr/testify/assert"
+)
+
+func TestIsSimpleTokenValid(t *testing.T) {
+	list := []string{"valid-token-1", "valid-token-2"}
+
+	tests := []struct {
+		name  string
+		list  []string
+		token string
+		exp   bool
+	}{
+		{name: "first_match", list: list, token: "valid-token-1", exp: true},
+		{name: "second_match", list: list, token: "valid-token-2", exp: true},
+		{name: "no_match", list: list, token: "not-a-token", exp: false},
+		{name: "empty_token", list: list, token: "", exp: false},
+		{name: "empty_list", list: nil, token: "anything", exp: false},
+		{name: "empty_token_empty_list", list: nil, token: "", exp: false},
+		// A prefix of a valid token must not authorize.
+		{name: "prefix_of_valid", list: list, token: "valid-token-", exp: false},
+	}
+
+	for i := range tests {
+		tc := tests[i]
+		t.Run(tc.name, func(t *testing.T) {
+			should.Equal(t, tc.exp, isSimpleTokenValid(tc.list, tc.token))
+		})
+	}
+}
+
+func TestBearerTokenMiddleware(t *testing.T) {
+	tests := []struct {
+		name   string
+		header string // empty => no Authorization header set
+		exp    string
+	}{
+		{name: "standard", header: "Bearer abc123", exp: "abc123"},
+		{name: "lowercase_scheme", header: "bearer abc123", exp: "abc123"},
+		{name: "uppercase_scheme", header: "BEARER abc123", exp: "abc123"},
+		{name: "missing_header", header: "", exp: ""},
+		{name: "scheme_only", header: "Bearer", exp: ""},
+		{name: "scheme_and_space_only", header: "Bearer ", exp: ""},
+		{name: "wrong_scheme", header: "Basic abc123", exp: ""},
+	}
+
+	for i := range tests {
+		tc := tests[i]
+		t.Run(tc.name, func(t *testing.T) {
+			var got string
+			var present bool
+			next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				got, present = r.Context().Value(bearerTokenKey{}).(string)
+			})
+
+			req := httptest.NewRequest(http.MethodGet, "/", nil)
+			if tc.header != "" {
+				req.Header.Set("Authorization", tc.header)
+			}
+			rec := httptest.NewRecorder()
+
+			BearerTokenMiddleware(next).ServeHTTP(rec, req)
+
+			should.True(t, present, "token key must always be set in context")
+			should.Equal(t, tc.exp, got)
+		})
+	}
+}
+
+func TestSimpleTokenAuthorizedOnly(t *testing.T) {
+	orig := TokenList
+	t.Cleanup(func() { TokenList = orig })
+	TokenList = []string{"secret"}
+
+	// Chain the two middlewares as the router does: BearerTokenMiddleware
+	// populates the context that SimpleTokenAuthorizedOnly reads.
+	handler := BearerTokenMiddleware(SimpleTokenAuthorizedOnly(
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+		}),
+	))
+
+	tests := []struct {
+		name   string
+		header string
+		exp    int
+	}{
+		{name: "valid_token", header: "Bearer secret", exp: http.StatusOK},
+		{name: "invalid_token", header: "Bearer wrong", exp: http.StatusForbidden},
+		{name: "missing_header", header: "", exp: http.StatusForbidden},
+		{name: "empty_token", header: "Bearer ", exp: http.StatusForbidden},
+	}
+
+	for i := range tests {
+		tc := tests[i]
+		t.Run(tc.name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodGet, "/", nil)
+			if tc.header != "" {
+				req.Header.Set("Authorization", tc.header)
+			}
+			rec := httptest.NewRecorder()
+
+			handler.ServeHTTP(rec, req)
+
+			should.Equal(t, tc.exp, rec.Code)
+		})
+	}
+}

--- a/server/server.go
+++ b/server/server.go
@@ -112,7 +112,6 @@ func init() {
 // Server - base server type
 type Server struct {
 	ListenPort   int          `json:"listen_port,omitempty"`
-	MaxTokens    int          `json:"max_tokens,omitempty"`
 	DBConfigPath string       `json:"db_config_path"`
 	Logger       *slog.Logger `json:",omitempty"`
 	dynamo       *dynamodb.DynamoDB

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -1,3 +1,6 @@
+//go:build db
+// +build db
+
 package server
 
 import (

--- a/server/tokens.go
+++ b/server/tokens.go
@@ -313,7 +313,7 @@ func (c *Server) blindedTokenRedeemHandlerV3(w http.ResponseWriter, r *http.Requ
 
 	if err := c.RedeemToken(issuer, request.TokenPreimage, request.Payload, 0); err != nil {
 		c.Logger.Error("error redeeming token")
-		if errors.Is(err, errDuplicateRedemption) {
+		if errors.Is(err, ErrDuplicateRedemption) {
 			_, equiv, eqErr := c.CheckRedeemedTokenEquivalence(issuer, request.TokenPreimage, request.Payload, 0)
 
 			// A replay of the original redemption is idempotent, not a conflict.
@@ -437,7 +437,7 @@ func (c *Server) blindedTokenRedeemHandler(w http.ResponseWriter, r *http.Reques
 		}
 
 		if err := c.RedeemToken(verifiedIssuer, request.TokenPreimage, request.Payload, 0); err != nil {
-			if errors.Is(err, errDuplicateRedemption) {
+			if errors.Is(err, ErrDuplicateRedemption) {
 				return &AppError{
 					Message: err.Error(),
 					Code:    http.StatusConflict,
@@ -523,7 +523,7 @@ func (c *Server) blindedTokenBulkRedeemHandler(w http.ResponseWriter, r *http.Re
 		if err := redeemTokenWithDB(tx, token.Issuer, token.TokenPreimage, request.Payload); err != nil {
 			c.Logger.Error(err.Error())
 			_ = tx.Rollback()
-			if err == errDuplicateRedemption {
+			if errors.Is(err, ErrDuplicateRedemption) {
 				return &AppError{
 					Message: err.Error(),
 					Code:    http.StatusConflict,

--- a/utils/ptr/ptr.go
+++ b/utils/ptr/ptr.go
@@ -7,19 +7,6 @@ func FromString(s string) *string {
 	return &s
 }
 
-// String returns value of pointer or empty string
-func String(s *string) string {
-	return StringOr(s, "")
-}
-
-// StringOr returns value of pointer or alternative value
-func StringOr(s *string, or string) string {
-	if s == nil {
-		return or
-	}
-	return *s
-}
-
 // FromTime - return the pointer from a time?
 func FromTime(t time.Time) *time.Time {
 	return &t


### PR DESCRIPTION
## Summary

Non-behavioral code-quality pass: removes dead/over-engineered code, makes
duplicate-redemption error handling use `errors.Is`, and adds unit coverage for
the auth middleware and the HTTP error/response contract. No production behavior
changes except where noted.

## Changes

### Dead code / over-engineering removal
- Remove unused `ptr.String` / `ptr.StringOr`.
- Drop the single-implementation `Cache[T]` interface; `CacheCollection` fields
  are now `*SimpleCache[T]` directly.
- Remove the unused `Server.MaxTokens` field.
- Remove a dead error-logging branch in `AppHandler.ServeHTTP`. It read a
  `"logger"` context key that nothing ever set, so it never executed. Handlers
  already log their own cause. Also drops the string-keyed context lookup.

### Error handling
- Export `ErrDuplicateRedemption` and lowercase its message, so
  cross-package callers can match it.
- Replace string-matching (`strings.Contains(err.Error(), "duplicate")`) and a
  `==` comparison with `errors.Is(err, ErrDuplicateRedemption)`.

### Tests & build
- Add `server/middleware_test.go`. It covers `isSimpleTokenValid`,
  `BearerTokenMiddleware` header parsing, and `SimpleTokenAuthorizedOnly` (403 vs
  200).
- Add `server/app_handler_test.go`. It covers `RenderContent`, `AppError.Error()`,
  and the `ServeHTTP` error envelope including the `equivalence` field.
- Gate the DB/dynamo-dependent suite behind `//go:build db` and point
  `make docker-test` at `-tags=db`, so plain `go test ./...` now runs the
  pure-unit set without needing Postgres/Dynamo.

## Testing
- New tests run under `make docker-test` (or `go test -tags=db ./server/` in the
  dev container); the ristretto FFI lib isn't linkable outside the container.