### PR TITLE
fix: several bugs

### DIFF
--- a/kafka/signed_blinded_token_issuer_handler.go
+++ b/kafka/signed_blinded_token_issuer_handler.go
@@ -146,9 +146,9 @@ OUTER:
 			)
 			kafkaErrorTotal.Inc()
 			var processingError *utils.ProcessingError
-			if errors.As(err, &processingError) {
+			if errors.As(appErr, &processingError) {
 				if processingError.Temporary {
-					return err
+					return appErr
 				}
 			}
 			blindedTokenResults = append(blindedTokenResults, avroSchema.SigningResultV2{
@@ -415,6 +415,21 @@ OUTER:
 			var signingKey *crypto.SigningKey
 			if len(issuer.Keys) > 0 {
 				signingKey = issuer.Keys[len(issuer.Keys)-1].CryptoSigningKey()
+			}
+
+			if signingKey == nil {
+				reqLogger.Error(
+					"invalid issuer, must have a usable signing key",
+					"issuerType", issuer.IssuerType,
+				)
+				kafkaErrorTotal.Inc()
+				blindedTokenResults = append(blindedTokenResults, avroSchema.SigningResultV2{
+					Signed_tokens:     nil,
+					Issuer_public_key: "",
+					Status:            issuerError,
+					Associated_data:   request.Associated_data,
+				})
+				continue OUTER
 			}
 
 			reqLogger.Debug("approving tokens", slog.Any("tokens", blindedTokens))

--- a/main.go
+++ b/main.go
@@ -52,6 +52,8 @@ func main() {
 			a.Crash(serverCtx, err)
 			panic(err)
 		}
+		// LoadConfigFile returns a fresh Server whose Logger is nil; restore it.
+		srv.Logger = logger
 	}
 
 	if port := os.Getenv("PORT"); port != "" {
@@ -111,14 +113,15 @@ func main() {
 
 func startKafka(srv server.Server, logger *slog.Logger, a alerter) {
 	ctx := context.Background()
-	logger.Debug("Initializing Kafka consumers")
-	err := kafka.StartConsumers(ctx, &srv, logger, a)
-
-	if err != nil {
+	for {
+		logger.Debug("Initializing Kafka consumers")
+		err := kafka.StartConsumers(ctx, &srv, logger, a)
+		if err == nil {
+			return
+		}
 		logger.Error("startkafka", slog.Any("error", err))
 		a.Outage(ctx, err)
-		// If err is something then start consumer again
+		// If err is something then start the consumers again.
 		time.Sleep(10 * time.Second)
-		startKafka(srv, logger, a)
 	}
 }

--- a/server/db.go
+++ b/server/db.go
@@ -603,7 +603,7 @@ func (c *Server) fetchIssuerKeys(fetchedIssuers []model.Issuer) ([]model.Issuer,
 }
 
 // RotateIssuers is the function that rotates
-func (c *Server) rotateIssuers() error {
+func (c *Server) rotateIssuers() (err error) {
 	cfg := c.dbConfig
 
 	tx, err := c.db.Begin()
@@ -613,7 +613,8 @@ func (c *Server) rotateIssuers() error {
 
 	defer func() {
 		if err != nil {
-			err = tx.Rollback()
+			// preserve the original error; a rollback failure must not mask it
+			_ = tx.Rollback()
 			return
 		}
 		err = tx.Commit()
@@ -684,7 +685,7 @@ func (c *Server) DeleteIssuerKeys(duration string) (int64, error) {
 }
 
 // rotateIssuersV3 is the function implementation that rotates time aware issuers
-func (c *Server) rotateIssuersV3() error {
+func (c *Server) rotateIssuersV3() (err error) {
 	tx, err := c.db.Begin()
 	if err != nil {
 		return err
@@ -692,7 +693,8 @@ func (c *Server) rotateIssuersV3() error {
 
 	defer func() {
 		if err != nil {
-			err = tx.Rollback()
+			// preserve the original error; a rollback failure must not mask it
+			_ = tx.Rollback()
 			return
 		}
 		err = tx.Commit()
@@ -1126,7 +1128,7 @@ func (c *Server) fetchRedemption(issuerType, id string) (*Redemption, error) {
 
 	queryTimer := prometheus.NewTimer(fetchRedemptionDBDuration)
 	rows, err := c.dbr.Query(
-		`SELECT id, issuer_id, ts, payload FROM redemptions WHERE id = $1 AND issuer_type = $2`, id, issuerType)
+		`SELECT id, issuer_type, ts, payload FROM redemptions WHERE id = $1 AND issuer_type = $2`, id, issuerType)
 	queryTimer.ObserveDuration()
 
 	if err != nil {

--- a/server/dynamo.go
+++ b/server/dynamo.go
@@ -124,7 +124,7 @@ func (c *Server) fetchRedemptionV2FromTable(id uuid.UUID, tableName string) (*Re
 	err = dynamodbattribute.UnmarshalMap(result.Item, &redemption)
 	if err != nil {
 		c.Logger.Error("Unable to unmarshal redemption")
-		panic(err)
+		return nil, err
 	}
 
 	if redemption.IssuerID == "" || redemption.ID == "" {

--- a/server/issuers.go
+++ b/server/issuers.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"context"
+	"database/sql"
 	"encoding/json"
 	"errors"
 	"io"
@@ -95,7 +96,7 @@ func (c *Server) GetLatestIssuerKafka(issuerType string, issuerCohort int16) (*m
 func (c *Server) getIssuers(ctx context.Context, issuerType string) ([]model.Issuer, *AppError) {
 	issuer, err := c.fetchIssuerByType(ctx, issuerType)
 	if err != nil {
-		if errors.Is(err, errIssuerNotFound) {
+		if errors.Is(err, errIssuerNotFound) || errors.Is(err, sql.ErrNoRows) {
 			return nil, &AppError{
 				Message: "Issuer not found",
 				Code:    404,


### PR DESCRIPTION
## Summary

Fixes a set of correctness bugs found while auditing the codebase.

## Fixes

- **Kafka token issuance is silently lost on a transient DB error.** The issuer
  fetch result is stored in `appErr`, but the temporary-vs-permanent check read
  the wrong variable (`err`, always nil at that point), so a temporary
  `ProcessingError` from a brief Postgres blip was treated as permanent.
- **Unknown issuer returned 500 instead of 404.** `getIssuers` only matched
  `errIssuerNotFound`, but `fetchIssuerByType` returns raw `sql.ErrNoRows`; added
  the `sql.ErrNoRows` case in the caller.
- **Issuer rotation swallowed commit failures.** `rotateIssuers`/`rotateIssuersV3`
  used unnamed `error` returns, so the deferred `tx.Commit()` result never reached
  the caller. A failed commit was reported as success. Switched to named returns
  and stopped the deferred rollback from masking the original error.
- **Malformed DynamoDB item panicked the request.** `fetchRedemptionV2FromTable`
  called `panic(err)` on an unmarshal failure; in the kafka redeem path
  this crashes the process. Now returns the error.
- **Nil signing-key dereference crashed the issuer consumer.** A non-time-aware
  issuer with no usable signing key left `signingKey == nil`, later dereferenced.
  Now emits an `issuerError` result and continues, matching the sibling error path.
- Restore `srv.Logger` after `LoadConfigFile` (it returns a fresh `Server` with a
  nil logger; the kafka path copies `srv` by value before it's reset).
- `startKafka` retried via unbounded recursion; converted to a loop to avoid stack
  growth during a sustained outage.